### PR TITLE
Basic Multipart support in Spring MVC

### DIFF
--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
@@ -43,12 +43,6 @@ public class FormParameterBean {
     @FormParameter("validated")
     private String validated;
 
-    @FormParameter("file")
-    private MultipartFile multipartFile;
-
-    @FormParameter("part")
-    private Part part;
-
     @BeanParameter
     private NestedBean nestedBean;
 
@@ -102,27 +96,82 @@ public class FormParameterBean {
         this.validated = validated;
     }
 
-    public MultipartFile getMultipartFile() {
-        return multipartFile;
-    }
-
-    public void setMultipartFile(MultipartFile multipartFile) {
-        this.multipartFile = multipartFile;
-    }
-
-    public Part getPart() {
-        return part;
-    }
-
-    public void setPart(Part part) {
-        this.part = part;
-    }
-
     public NestedBean getNestedBean() {
         return nestedBean;
     }
 
     public void setNestedBean(NestedBean nestedBean) {
         this.nestedBean = nestedBean;
+    }
+
+    /**
+     * Test bean for multipart binding in a Servlet/WebMVC application
+     */
+    static class ServletMultipartBean {
+        @FormParameter("file")
+        private MultipartFile multipartFile;
+
+        @FormParameter("part")
+        private Part part;
+
+        @FormParameter
+        private Map<String, MultipartFile> multipartFileMap;
+
+        @FormParameter
+        private MultiValueMap<String, MultipartFile> multiValueMultipartMap;
+
+        @FormParameter
+        private Map<String, Part> partMap;
+
+        @FormParameter
+        private MultiValueMap<String, Part> multiValuePartMap;
+
+        public MultipartFile getMultipartFile() {
+            return multipartFile;
+        }
+
+        public void setMultipartFile(MultipartFile multipartFile) {
+            this.multipartFile = multipartFile;
+        }
+
+        public Part getPart() {
+            return part;
+        }
+
+        public void setPart(Part part) {
+            this.part = part;
+        }
+
+        public Map<String, MultipartFile> getMultipartFileMap() {
+            return multipartFileMap;
+        }
+
+        public void setMultipartFileMap(Map<String, MultipartFile> multipartFileMap) {
+            this.multipartFileMap = multipartFileMap;
+        }
+
+        public MultiValueMap<String, MultipartFile> getMultiValueMultipartMap() {
+            return multiValueMultipartMap;
+        }
+
+        public void setMultiValueMultipartMap(MultiValueMap<String, MultipartFile> multiValueMultipartMap) {
+            this.multiValueMultipartMap = multiValueMultipartMap;
+        }
+
+        public Map<String, Part> getPartMap() {
+            return partMap;
+        }
+
+        public void setPartMap(Map<String, Part> partMap) {
+            this.partMap = partMap;
+        }
+
+        public MultiValueMap<String, Part> getMultiValuePartMap() {
+            return multiValuePartMap;
+        }
+
+        public void setMultiValuePartMap(MultiValueMap<String, Part> multiValuePartMap) {
+            this.multiValuePartMap = multiValuePartMap;
+        }
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
@@ -21,6 +21,7 @@ import com.mattbertolini.spring.web.bind.annotation.FormParameter;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Part;
 import javax.validation.constraints.NotEmpty;
 import java.util.Map;
 
@@ -44,6 +45,9 @@ public class FormParameterBean {
 
     @FormParameter("file")
     private MultipartFile multipartFile;
+
+    @FormParameter("part")
+    private Part part;
 
     @BeanParameter
     private NestedBean nestedBean;
@@ -104,6 +108,14 @@ public class FormParameterBean {
 
     public void setMultipartFile(MultipartFile multipartFile) {
         this.multipartFile = multipartFile;
+    }
+
+    public Part getPart() {
+        return part;
+    }
+
+    public void setPart(Part part) {
+        this.part = part;
     }
 
     public NestedBean getNestedBean() {

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.mattbertolini.spring.test.web.bind;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import com.mattbertolini.spring.web.bind.annotation.FormParameter;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotEmpty;
 import java.util.Map;
@@ -40,6 +41,9 @@ public class FormParameterBean {
     @NotEmpty
     @FormParameter("validated")
     private String validated;
+
+    @FormParameter("file")
+    private MultipartFile multipartFile;
 
     @BeanParameter
     private NestedBean nestedBean;
@@ -92,6 +96,14 @@ public class FormParameterBean {
 
     public void setValidated(String validated) {
         this.validated = validated;
+    }
+
+    public MultipartFile getMultipartFile() {
+        return multipartFile;
+    }
+
+    public void setMultipartFile(MultipartFile multipartFile) {
+        this.multipartFile = multipartFile;
     }
 
     public NestedBean getNestedBean() {

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.util.Map;
@@ -63,6 +64,15 @@ public class FormParameterController {
     @PostMapping(value = "/validated", produces = MediaType.TEXT_PLAIN_VALUE)
     public String validated(@Valid @BeanParameter FormParameterBean formParameterBean) {
         return formParameterBean.getValidated();
+    }
+
+    @PostMapping(value = "/multipartFile", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String multipartFile(@BeanParameter FormParameterBean formParameterBean) throws Exception {
+        MultipartFile multipartFile = formParameterBean.getMultipartFile();
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw new RuntimeException("Multipart file is null or empty");
+        }
+        return new String(multipartFile.getBytes());
     }
 
     @PostMapping(value = "/validatedWithBindingResult", produces = MediaType.TEXT_PLAIN_VALUE)

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterBean.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ package com.mattbertolini.spring.test.web.bind;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Part;
 import javax.validation.constraints.NotEmpty;
 import java.util.Map;
 
@@ -100,5 +102,76 @@ public class RequestParameterBean {
 
     public void setNestedBean(NestedBean nestedBean) {
         this.nestedBean = nestedBean;
+    }
+
+    /**
+     * Test bean for multipart binding in a Servlet/WebMVC application
+     */
+    static class ServletMultipartBean {
+        @RequestParameter("file")
+        private MultipartFile multipartFile;
+
+        @RequestParameter("part")
+        private Part part;
+
+        @RequestParameter
+        private Map<String, MultipartFile> multipartFileMap;
+
+        @RequestParameter
+        private MultiValueMap<String, MultipartFile> multiValueMultipartMap;
+
+        @RequestParameter
+        private Map<String, Part> partMap;
+
+        @RequestParameter
+        private MultiValueMap<String, Part> multiValuePartMap;
+
+        public MultipartFile getMultipartFile() {
+            return multipartFile;
+        }
+
+        public void setMultipartFile(MultipartFile multipartFile) {
+            this.multipartFile = multipartFile;
+        }
+
+        public Part getPart() {
+            return part;
+        }
+
+        public void setPart(Part part) {
+            this.part = part;
+        }
+
+        public Map<String, MultipartFile> getMultipartFileMap() {
+            return multipartFileMap;
+        }
+
+        public void setMultipartFileMap(Map<String, MultipartFile> multipartFileMap) {
+            this.multipartFileMap = multipartFileMap;
+        }
+
+        public MultiValueMap<String, MultipartFile> getMultiValueMultipartMap() {
+            return multiValueMultipartMap;
+        }
+
+        public void setMultiValueMultipartMap(MultiValueMap<String, MultipartFile> multiValueMultipartMap) {
+            this.multiValueMultipartMap = multiValueMultipartMap;
+        }
+
+        public Map<String, Part> getPartMap() {
+            return partMap;
+        }
+
+        public void setPartMap(Map<String, Part> partMap) {
+            this.partMap = partMap;
+        }
+
+        public MultiValueMap<String, Part> getMultiValuePartMap() {
+            return multiValuePartMap;
+        }
+
+        public void setMultiValuePartMap(MultiValueMap<String, Part> multiValuePartMap) {
+            this.multiValuePartMap = multiValuePartMap;
+        }
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,20 @@ package com.mattbertolini.spring.test.web.bind;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StreamUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Part;
 import javax.validation.Valid;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 public class RequestParameterController {
@@ -71,6 +79,67 @@ public class RequestParameterController {
             return "notValid";
         }
         return "valid";
+    }
+
+    @PostMapping(value = "/multipartFile", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String multipartFile(@BeanParameter RequestParameterBean.ServletMultipartBean requestParameterBean) throws Exception {
+        MultipartFile multipartFile = requestParameterBean.getMultipartFile();
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw new RuntimeException("Multipart file is null or empty");
+        }
+        return new String(multipartFile.getBytes());
+    }
+
+    @PostMapping(value = "/part", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String part(@BeanParameter RequestParameterBean.ServletMultipartBean requestParameterBean) throws Exception {
+        Part part = requestParameterBean.getPart();
+        if (part == null || part.getSize() <= 0) {
+            throw new RuntimeException("Multipart file is null or empty");
+        }
+        return StreamUtils.copyToString(part.getInputStream(), StandardCharsets.UTF_8);
+    }
+
+    @PostMapping(value = "/multipartFileMap", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String multipartFileMap(@BeanParameter RequestParameterBean.ServletMultipartBean requestParameterBean) throws Exception {
+        Map<String, MultipartFile> multipartFileMap = requestParameterBean.getMultipartFileMap();
+        MultipartFile fileOne = multipartFileMap.get("fileOne");
+        MultipartFile fileTwo = multipartFileMap.get("fileTwo");
+        return new String(fileOne.getBytes()) + ", " + new String(fileTwo.getBytes());
+    }
+
+    @PostMapping(value = "/multiValueMultipartFileMap", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String multiValueMultipartFileMap(@BeanParameter RequestParameterBean.ServletMultipartBean requestParameterBean) {
+        MultiValueMap<String, MultipartFile> multiValueMultipartMap = requestParameterBean.getMultiValueMultipartMap();
+        List<MultipartFile> files = multiValueMultipartMap.get("file");
+        return files.stream().map(multipartFile -> {
+            try {
+                return new String(multipartFile.getBytes());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.joining(", "));
+    }
+
+    @PostMapping(value = "/partMap", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String partMap(@BeanParameter RequestParameterBean.ServletMultipartBean requestParameterBean) throws Exception {
+        Map<String, Part> partMap = requestParameterBean.getPartMap();
+        Part fileOne = partMap.get("fileOne");
+        Part fileTwo = partMap.get("fileTwo");
+        return StreamUtils.copyToString(fileOne.getInputStream(), StandardCharsets.UTF_8)
+            + ", " + StreamUtils.copyToString(fileTwo.getInputStream(), StandardCharsets.UTF_8);
+    }
+
+    @PostMapping(value = "/multiValuePartMap", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String multiValuePartMap(@BeanParameter RequestParameterBean.ServletMultipartBean requestParameterBean) {
+        MultiValueMap<String, Part> multiValuePartMap = requestParameterBean.getMultiValuePartMap();
+        List<Part> files = multiValuePartMap.get("file");
+        return files.stream().map(part -> {
+            try {
+                return StreamUtils.copyToString(part.getInputStream(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.joining(", "));
     }
 
     @GetMapping(value = "/nested", produces = MediaType.TEXT_PLAIN_VALUE)

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +31,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -99,6 +103,23 @@ class FormParameterIntegrationTest {
             .accept(MediaType.TEXT_PLAIN))
             .andExpect(status().isOk())
             .andExpect(content().string("notValid"));
+    }
+
+    @Test
+    void bindsMultipartFile() throws Exception {
+        String expected = "this is a multipart file";
+        MockMultipartFile multipartFile = new MockMultipartFile(
+            "file",
+            "mockFile.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            expected.getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multipartFile")
+            .file(multipartFile)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string(expected));
     }
 
     @Test

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.servlet.MockMvc;
@@ -116,6 +117,22 @@ class FormParameterIntegrationTest {
         );
         mockMvc.perform(multipart("/multipartFile")
             .file(multipartFile)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string(expected));
+    }
+
+    @Test
+    void bindsPart() throws Exception {
+        String expected = "this is a file part";
+        MockPart part = new MockPart(
+            "part",
+            "mockFile.txt",
+            expected.getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/part")
+            .part(part)
             .contentType(MediaType.MULTIPART_FORM_DATA)
             .accept(MediaType.TEXT_PLAIN))
             .andExpect(status().isOk())

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
@@ -140,6 +140,94 @@ class FormParameterIntegrationTest {
     }
 
     @Test
+    void bindsMultipartFileMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile(
+            "fileOne",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockMultipartFile fileTwo = new MockMultipartFile(
+            "fileTwo",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multipartFileMap")
+            .file(fileOne)
+            .file(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
+    }
+
+    @Test
+    void bindsMultiValueMultipartFileMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile(
+            "file",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockMultipartFile fileTwo = new MockMultipartFile(
+            "file",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multiValueMultipartFileMap")
+            .file(fileOne)
+            .file(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
+    }
+
+    @Test
+    void bindsPartMap() throws Exception {
+        MockPart fileOne = new MockPart(
+            "fileOne",
+            "fileOne.txt",
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockPart fileTwo = new MockPart(
+            "fileTwo",
+            "fileTwo.txt",
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/partMap")
+            .part(fileOne)
+            .part(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
+    }
+
+    @Test
+    void bindsMultiValuePartMap() throws Exception {
+        MockPart fileOne = new MockPart(
+            "file",
+            "fileOne.txt",
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockPart fileTwo = new MockPart(
+            "file",
+            "fileTwo.txt",
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multiValuePartMap")
+            .part(fileOne)
+            .part(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
+    }
+
+    @Test
     void bindsNestedBean() throws Exception {
         makeRequest("/nested", "nested_form_param=expectedValue")
             .andExpect(status().isOk())

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,7 +33,10 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -100,6 +105,127 @@ class RequestParameterIntegrationTest {
             .accept(MediaType.TEXT_PLAIN))
             .andExpect(status().isOk())
             .andExpect(content().string("notValid"));
+    }
+
+    @Test
+    void bindsMultipartFile() throws Exception {
+        String expected = "this is a multipart file";
+        MockMultipartFile multipartFile = new MockMultipartFile(
+            "file",
+            "mockFile.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            expected.getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multipartFile")
+            .file(multipartFile)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string(expected));
+    }
+
+    @Test
+    void bindsPart() throws Exception {
+        String expected = "this is a file part";
+        MockPart part = new MockPart(
+            "part",
+            "mockFile.txt",
+            expected.getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/part")
+            .part(part)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string(expected));
+    }
+
+    @Test
+    void bindsMultipartFileMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile(
+            "fileOne",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockMultipartFile fileTwo = new MockMultipartFile(
+            "fileTwo",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multipartFileMap")
+            .file(fileOne)
+            .file(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
+    }
+
+    @Test
+    void bindsMultiValueMultipartFileMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile(
+            "file",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockMultipartFile fileTwo = new MockMultipartFile(
+            "file",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multiValueMultipartFileMap")
+            .file(fileOne)
+            .file(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
+    }
+
+    @Test
+    void bindsPartMap() throws Exception {
+        MockPart fileOne = new MockPart(
+            "fileOne",
+            "fileOne.txt",
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockPart fileTwo = new MockPart(
+            "fileTwo",
+            "fileTwo.txt",
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/partMap")
+            .part(fileOne)
+            .part(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
+    }
+
+    @Test
+    void bindsMultiValuePartMap() throws Exception {
+        MockPart fileOne = new MockPart(
+            "file",
+            "fileOne.txt",
+            "fileOneValue".getBytes(StandardCharsets.UTF_8)
+        );
+        MockPart fileTwo = new MockPart(
+            "file",
+            "fileTwo.txt",
+            "fileTwoValue".getBytes(StandardCharsets.UTF_8)
+        );
+        mockMvc.perform(multipart("/multiValuePartMap")
+            .part(fileOne)
+            .part(fileTwo)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isOk())
+            .andExpect(content().string("fileOneValue, fileTwoValue"));
     }
 
     @Test

--- a/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolver.java
+++ b/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,25 @@
 
 package com.mattbertolini.spring.web.servlet.mvc.bind.resolver;
 
+import com.mattbertolini.spring.web.bind.PropertyResolutionException;
 import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
+import org.springframework.core.ResolvableType;
 import org.springframework.lang.NonNull;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartRequest;
+import org.springframework.web.multipart.support.MultipartResolutionDelegate;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Part;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -39,9 +49,20 @@ public class RequestParameterMapRequestPropertyResolver implements RequestProper
 
     @Override
     public Object resolve(@NonNull BindingProperty bindingProperty, @NonNull NativeWebRequest request) {
-        Map<String, String[]> parameterMap = request.getParameterMap();
+        ResolvableType resolvableType = ResolvableType.forMethodParameter(bindingProperty.getMethodParameter());
 
+        // Multipart params
         if (MultiValueMap.class.isAssignableFrom(bindingProperty.getType())) {
+            Class<?> mapValueType = resolvableType.as(MultiValueMap.class).getGeneric(1).resolve();
+            if (MultipartFile.class == mapValueType) {
+                MultipartRequest multipartRequest = MultipartResolutionDelegate.resolveMultipartRequest(request);
+                return (multipartRequest != null ? multipartRequest.getMultiFileMap() : new LinkedMultiValueMap<>());
+            } else if (Part.class == mapValueType) {
+                return resolveServletRequestPartsToMultiValueMap(request);
+            }
+
+            // Standard params
+            Map<String, String[]> parameterMap = request.getParameterMap();
             MultiValueMap<String, String> ret = new LinkedMultiValueMap<>(parameterMap.size());
             for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
                 ret.put(entry.getKey(), new LinkedList<>(Arrays.asList(entry.getValue())));
@@ -49,10 +70,57 @@ public class RequestParameterMapRequestPropertyResolver implements RequestProper
             return ret;
         }
 
+        // Multipart params
+        Class<?> mapValueType = resolvableType.asMap().getGeneric(1).resolve();
+        if (MultipartFile.class == mapValueType) {
+            MultipartRequest multipartRequest = MultipartResolutionDelegate.resolveMultipartRequest(request);
+            return (multipartRequest != null ? multipartRequest.getFileMap() : new LinkedHashMap<>());
+        } else if (Part.class == mapValueType) {
+            return resolveServletRequestPartsToMap(request);
+        }
+
+        // Standard params
+        Map<String, String[]> parameterMap = request.getParameterMap();
         Map<String, String> ret = new LinkedHashMap<>(parameterMap.size());
         for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
             ret.put(entry.getKey(), entry.getValue()[0]);
         }
         return ret;
+    }
+
+    private LinkedMultiValueMap<?, ?> resolveServletRequestPartsToMultiValueMap(NativeWebRequest request) {
+        try {
+            HttpServletRequest servletRequest = request.getNativeRequest(HttpServletRequest.class);
+            if (servletRequest != null && MultipartResolutionDelegate.isMultipartRequest(servletRequest)) {
+                Collection<Part> parts = servletRequest.getParts();
+                LinkedMultiValueMap<String, Part> result = new LinkedMultiValueMap<>(parts.size());
+                for (Part part : parts) {
+                    result.add(part.getName(), part);
+                }
+                return result;
+            }
+            return new LinkedMultiValueMap<>();
+        } catch (IOException | ServletException e) {
+            throw new PropertyResolutionException("Exception resolving multipart objects into MultiValueMap.", e);
+        }
+    }
+
+    private LinkedHashMap<?, ?> resolveServletRequestPartsToMap(NativeWebRequest request) {
+        try {
+            HttpServletRequest servletRequest = request.getNativeRequest(HttpServletRequest.class);
+            if (servletRequest != null && MultipartResolutionDelegate.isMultipartRequest(servletRequest)) {
+                Collection<Part> parts = servletRequest.getParts();
+                LinkedHashMap<String, Part> result = new LinkedHashMap<>(parts.size());
+                for (Part part : parts) {
+                    if (!result.containsKey(part.getName())) {
+                        result.put(part.getName(), part);
+                    }
+                }
+                return result;
+            }
+            return new LinkedHashMap<>();
+        } catch (IOException | ServletException e) {
+            throw new PropertyResolutionException("Exception resolving multipart objects into Map", e);
+        }
     }
 }

--- a/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolver.java
+++ b/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.multipart.MultipartRequest;
 
 public class RequestParameterRequestPropertyResolver extends AbstractNamedRequestPropertyResolver<NativeWebRequest, Object>
     implements RequestPropertyResolver {
@@ -35,6 +36,10 @@ public class RequestParameterRequestPropertyResolver extends AbstractNamedReques
 
     @Override
     protected Object resolveWithName(@NonNull BindingProperty bindingProperty, String name, @NonNull NativeWebRequest request) {
+        MultipartRequest multipartRequest = request.getNativeRequest(MultipartRequest.class);
+        if (multipartRequest != null) {
+            return multipartRequest.getFiles(name);
+        }
         return request.getParameterValues(name);
     }
     

--- a/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolver.java
+++ b/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolver.java
@@ -24,7 +24,6 @@ import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.multipart.MultipartRequest;
 import org.springframework.web.multipart.support.MultipartResolutionDelegate;
 
 import javax.servlet.http.HttpServletRequest;

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/ExceptionThrowingMockMultipartHttpServletRequest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/ExceptionThrowingMockMultipartHttpServletRequest.java
@@ -3,9 +3,19 @@ package com.mattbertolini.spring.web.servlet.mvc.bind.resolver;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.Part;
+import java.io.IOException;
+import java.util.Collection;
+
 public class ExceptionThrowingMockMultipartHttpServletRequest extends MockMultipartHttpServletRequest {
     @Override
     public MultipartFile getFile(String name) {
-        throw new RuntimeException("Failure");
+        throw new RuntimeException("Failure in getFile");
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        throw new ServletException("Failure in getParts");
     }
 }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/ExceptionThrowingMockMultipartHttpServletRequest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/ExceptionThrowingMockMultipartHttpServletRequest.java
@@ -1,0 +1,11 @@
+package com.mattbertolini.spring.web.servlet.mvc.bind.resolver;
+
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ExceptionThrowingMockMultipartHttpServletRequest extends MockMultipartHttpServletRequest {
+    @Override
+    public MultipartFile getFile(String name) {
+        throw new RuntimeException("Failure");
+    }
+}

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterMapRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterMapRequestPropertyResolverTest.java
@@ -273,20 +273,22 @@ class FormParameterMapRequestPropertyResolverTest {
     }
 
     @Test
-    void throwsExceptionReadingMultipartRequestForMap() {
+    void throwsExceptionReadingMultipartRequestForMap() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
         ServletWebRequest request = new ServletWebRequest(multipartRequest);
 
-        assertThatThrownBy(() -> resolver.resolve(bindingProperty("partMap"), request))
+        BindingProperty bindingProperty = bindingProperty("partMap");
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty, request))
             .isInstanceOf(PropertyResolutionException.class);
     }
 
     @Test
-    void throwsExceptionReadingMultipartRequestForMultiValueMap() {
+    void throwsExceptionReadingMultipartRequestForMultiValueMap() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
         ServletWebRequest request = new ServletWebRequest(multipartRequest);
 
-        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multiValuePartMap"), request))
+        BindingProperty bindingProperty = bindingProperty("multiValuePartMap");
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty, request))
             .isInstanceOf(PropertyResolutionException.class);
     }
 

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterMapRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterMapRequestPropertyResolverTest.java
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.web.servlet.mvc.bind.resolver;
 
+import com.mattbertolini.spring.web.bind.PropertyResolutionException;
 import com.mattbertolini.spring.web.bind.annotation.FormParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FormParameterMapRequestPropertyResolverTest {
     private FormParameterMapRequestPropertyResolver resolver;
@@ -220,6 +222,72 @@ class FormParameterMapRequestPropertyResolverTest {
         assertThat(actual).isInstanceOf(Map.class);
         Map<String, Part> map = (Map<String, Part>) actual;
         assertThat(map).containsEntry("file", fileOne);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyMultiValueMultipartFileMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValueMultipartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, MultipartFile> map = (MultiValueMap<String, MultipartFile>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyMultipartFileMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multipartFileMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, MultipartFile> map = (Map<String, MultipartFile>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyPartMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("partMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, Part> map = (Map<String, Part>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyPartMultiValueMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValuePartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, Part> map = (MultiValueMap<String, Part>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    void throwsExceptionReadingMultipartRequestForMap() {
+        MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty("partMap"), request))
+            .isInstanceOf(PropertyResolutionException.class);
+    }
+
+    @Test
+    void throwsExceptionReadingMultipartRequestForMultiValueMap() {
+        MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multiValuePartMap"), request))
+            .isInstanceOf(PropertyResolutionException.class);
     }
 
     private BindingProperty bindingProperty(String property) throws IntrospectionException {

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterMapRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterMapRequestPropertyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,19 @@ import com.mattbertolini.spring.web.bind.annotation.FormParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.mock.web.MockPart;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Part;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -87,6 +94,134 @@ class FormParameterMapRequestPropertyResolverTest {
         assertThat(map).containsEntry("form_param", "one");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsMultipartFileMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile("file_one",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile fileTwo = new MockMultipartFile("file_two",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addFile(fileOne);
+        multipartRequest.addFile(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multipartFileMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, MultipartFile> map = (Map<String, MultipartFile>) actual;
+        assertThat(map).containsEntry("file_one", fileOne)
+            .containsEntry("file_two", fileTwo);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsMultipartFileMultiValueMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile("file",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile fileTwo = new MockMultipartFile("file",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addFile(fileOne);
+        multipartRequest.addFile(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValueMultipartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, MultipartFile> map = (MultiValueMap<String, MultipartFile>) actual;
+        assertThat(map).containsEntry("file", Arrays.asList(fileOne, fileTwo));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsFirstMultipartFileInMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile("file",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile fileTwo = new MockMultipartFile("file",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addFile(fileOne);
+        multipartRequest.addFile(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multipartFileMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, MultipartFile> map = (Map<String, MultipartFile>) actual;
+        assertThat(map).containsEntry("file", fileOne);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsPartMap() throws Exception {
+        MockPart fileOne = new MockPart("file_one",
+            "fileOne.txt",
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockPart fileTwo = new MockPart("file_two",
+            "fileTwo.txt",
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addPart(fileOne);
+        multipartRequest.addPart(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("partMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, Part> map = (Map<String, Part>) actual;
+        assertThat(map).containsEntry("file_one", fileOne)
+            .containsEntry("file_two", fileTwo);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsPartMultiValueMap() throws Exception {
+        MockPart fileOne = new MockPart("file",
+            "fileOne.txt",
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockPart fileTwo = new MockPart("file",
+            "fileTwo.txt",
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addPart(fileOne);
+        multipartRequest.addPart(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValuePartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, Part> map = (MultiValueMap<String, Part>) actual;
+        assertThat(map).containsEntry("file", Arrays.asList(fileOne, fileTwo));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsFirstPartInMap() throws Exception {
+        MockPart fileOne = new MockPart("file",
+            "fileOne.txt",
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockPart fileTwo = new MockPart("file",
+            "fileTwo.txt",
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addPart(fileOne);
+        multipartRequest.addPart(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("partMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, Part> map = (Map<String, Part>) actual;
+        assertThat(map).containsEntry("file", fileOne);
+    }
+
     private BindingProperty bindingProperty(String property) throws IntrospectionException {
         return BindingProperty.forPropertyDescriptor(new PropertyDescriptor(property, TestingBean.class));
     }
@@ -106,6 +241,18 @@ class FormParameterMapRequestPropertyResolverTest {
 
         @FormParameter
         private String notAMap;
+
+        @FormParameter
+        private Map<String, MultipartFile> multipartFileMap;
+
+        @FormParameter
+        private MultiValueMap<String, MultipartFile> multiValueMultipartMap;
+
+        @FormParameter
+        private Map<String, Part> partMap;
+
+        @FormParameter
+        private MultiValueMap<String, Part> multiValuePartMap;
 
         public Map<String, String> getAnnotated() {
             return annotated;
@@ -145,6 +292,38 @@ class FormParameterMapRequestPropertyResolverTest {
 
         public void setNotAMap(String notAMap) {
             this.notAMap = notAMap;
+        }
+
+        public Map<String, MultipartFile> getMultipartFileMap() {
+            return multipartFileMap;
+        }
+
+        public void setMultipartFileMap(Map<String, MultipartFile> multipartFileMap) {
+            this.multipartFileMap = multipartFileMap;
+        }
+
+        public MultiValueMap<String, MultipartFile> getMultiValueMultipartMap() {
+            return multiValueMultipartMap;
+        }
+
+        public void setMultiValueMultipartMap(MultiValueMap<String, MultipartFile> multiValueMultipartMap) {
+            this.multiValueMultipartMap = multiValueMultipartMap;
+        }
+
+        public Map<String, Part> getPartMap() {
+            return partMap;
+        }
+
+        public void setPartMap(Map<String, Part> partMap) {
+            this.partMap = partMap;
+        }
+
+        public MultiValueMap<String, Part> getMultiValuePartMap() {
+            return multiValuePartMap;
+        }
+
+        public void setMultiValuePartMap(MultiValueMap<String, Part> multiValuePartMap) {
+            this.multiValuePartMap = multiValuePartMap;
         }
     }
 }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
@@ -24,13 +24,14 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.mock.web.MockPart;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Part;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,8 +100,7 @@ class FormParameterRequestPropertyResolverTest {
         Object actual = resolver.resolve(bindingProperty("multipleValues"), request);
         assertThat(actual).isEqualTo(expected);
     }
-
-    @SuppressWarnings("unchecked")
+    
     @Test
     void returnsMultipartFile() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
@@ -114,7 +114,22 @@ class FormParameterRequestPropertyResolverTest {
         
         Object actual = resolver.resolve(bindingProperty("multipartFile"), new ServletWebRequest(multipartRequest));
         assertThat(actual).isNotNull();
-        assertThat((Collection<MultipartFile>) actual).hasSize(1).first().isEqualTo(multipartFile);
+        assertThat((MultipartFile) actual).isEqualTo(multipartFile);
+    }
+
+    @Test
+    void returnsPart() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        MockPart part = new MockPart(
+            "part",
+            "testfile.txt",
+            "testing".getBytes(StandardCharsets.UTF_8)
+        );
+        multipartRequest.addPart(part);
+
+        Object actual = resolver.resolve(bindingProperty("part"), new ServletWebRequest(multipartRequest));
+        assertThat(actual).isNotNull();
+        assertThat((Part) actual).isEqualTo(part);
     }
 
     private BindingProperty bindingProperty(String property) throws IntrospectionException {
@@ -136,6 +151,9 @@ class FormParameterRequestPropertyResolverTest {
 
         @FormParameter("multipart_file")
         private MultipartFile multipartFile;
+
+        @FormParameter("part")
+        private Part part;
 
         public String getAnnotated() {
             return annotated;
@@ -175,6 +193,14 @@ class FormParameterRequestPropertyResolverTest {
 
         public void setMultipartFile(MultipartFile multipartFile) {
             this.multipartFile = multipartFile;
+        }
+
+        public Part getPart() {
+            return part;
+        }
+
+        public void setPart(Part part) {
+            this.part = part;
         }
     }
 }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
@@ -157,11 +157,12 @@ class FormParameterRequestPropertyResolverTest {
     }
 
     @Test
-    void throwsExceptionReadingMultipartRequest() {
+    void throwsExceptionReadingMultipartRequest() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
         ServletWebRequest request = new ServletWebRequest(multipartRequest);
 
-        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multipartFile"), request))
+        BindingProperty bindingProperty = bindingProperty("multipartFile");
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty, request))
             .isInstanceOf(PropertyResolutionException.class);
     }
 

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.web.servlet.mvc.bind.resolver;
 
+import com.mattbertolini.spring.web.bind.PropertyResolutionException;
 import com.mattbertolini.spring.web.bind.annotation.FormParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FormParameterRequestPropertyResolverTest {
     private FormParameterRequestPropertyResolver resolver;
@@ -152,6 +154,15 @@ class FormParameterRequestPropertyResolverTest {
         Object actual = resolver.resolve(bindingProperty("multipartFile"), request);
         assertThat(actual).isNotNull();
         assertThat((MultipartFile) actual).isEqualTo(multipartFile);
+    }
+
+    @Test
+    void throwsExceptionReadingMultipartRequest() {
+        MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multipartFile"), request))
+            .isInstanceOf(PropertyResolutionException.class);
     }
 
     private BindingProperty bindingProperty(String property) throws IntrospectionException {

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/FormParameterRequestPropertyResolverTest.java
@@ -132,6 +132,28 @@ class FormParameterRequestPropertyResolverTest {
         assertThat((Part) actual).isEqualTo(part);
     }
 
+    @Test
+    void returnsMultipartFileAndFormParameter() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile(
+            "multipart_file",
+            "testfile.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "testing".getBytes(StandardCharsets.UTF_8)
+        );
+
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addParameter("testing", "formValue");
+        multipartRequest.addFile(multipartFile);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object formValue = resolver.resolve(bindingProperty("annotated"), request);
+        assertThat(formValue).isEqualTo(new String[]{"formValue"});
+
+        Object actual = resolver.resolve(bindingProperty("multipartFile"), request);
+        assertThat(actual).isNotNull();
+        assertThat((MultipartFile) actual).isEqualTo(multipartFile);
+    }
+
     private BindingProperty bindingProperty(String property) throws IntrospectionException {
         return BindingProperty.forPropertyDescriptor(new PropertyDescriptor(property, TestingBean.class));
     }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolverTest.java
@@ -273,20 +273,22 @@ class RequestParameterMapRequestPropertyResolverTest {
     }
 
     @Test
-    void throwsExceptionReadingMultipartRequestForMap() {
+    void throwsExceptionReadingMultipartRequestForMap() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
         ServletWebRequest request = new ServletWebRequest(multipartRequest);
 
-        assertThatThrownBy(() -> resolver.resolve(bindingProperty("partMap"), request))
+        BindingProperty bindingProperty = bindingProperty("partMap");
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty, request))
             .isInstanceOf(PropertyResolutionException.class);
     }
 
     @Test
-    void throwsExceptionReadingMultipartRequestForMultiValueMap() {
+    void throwsExceptionReadingMultipartRequestForMultiValueMap() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
         ServletWebRequest request = new ServletWebRequest(multipartRequest);
 
-        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multiValuePartMap"), request))
+        BindingProperty bindingProperty = bindingProperty("multiValuePartMap");
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty, request))
             .isInstanceOf(PropertyResolutionException.class);
     }
 

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolverTest.java
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.web.servlet.mvc.bind.resolver;
 
+import com.mattbertolini.spring.web.bind.PropertyResolutionException;
 import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RequestParameterMapRequestPropertyResolverTest {
     private RequestParameterMapRequestPropertyResolver resolver;
@@ -220,6 +222,72 @@ class RequestParameterMapRequestPropertyResolverTest {
         assertThat(actual).isInstanceOf(Map.class);
         Map<String, Part> map = (Map<String, Part>) actual;
         assertThat(map).containsEntry("file", fileOne);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyMultiValueMultipartFileMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValueMultipartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, MultipartFile> map = (MultiValueMap<String, MultipartFile>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyMultipartFileMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multipartFileMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, MultipartFile> map = (Map<String, MultipartFile>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyPartMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("partMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, Part> map = (Map<String, Part>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsEmptyPartMultiValueMap() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValuePartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, Part> map = (MultiValueMap<String, Part>) actual;
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    void throwsExceptionReadingMultipartRequestForMap() {
+        MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty("partMap"), request))
+            .isInstanceOf(PropertyResolutionException.class);
+    }
+
+    @Test
+    void throwsExceptionReadingMultipartRequestForMultiValueMap() {
+        MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multiValuePartMap"), request))
+            .isInstanceOf(PropertyResolutionException.class);
     }
 
     private BindingProperty bindingProperty(String property) throws IntrospectionException {

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterMapRequestPropertyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,19 @@ import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.mock.web.MockPart;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Part;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -87,6 +94,134 @@ class RequestParameterMapRequestPropertyResolverTest {
         assertThat(map).containsEntry("request_param", "one");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsMultipartFileMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile("file_one",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile fileTwo = new MockMultipartFile("file_two",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addFile(fileOne);
+        multipartRequest.addFile(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multipartFileMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, MultipartFile> map = (Map<String, MultipartFile>) actual;
+        assertThat(map).containsEntry("file_one", fileOne)
+            .containsEntry("file_two", fileTwo);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsMultipartFileMultiValueMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile("file",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile fileTwo = new MockMultipartFile("file",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addFile(fileOne);
+        multipartRequest.addFile(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValueMultipartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, MultipartFile> map = (MultiValueMap<String, MultipartFile>) actual;
+        assertThat(map).containsEntry("file", Arrays.asList(fileOne, fileTwo));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsFirstMultipartFileInMap() throws Exception {
+        MockMultipartFile fileOne = new MockMultipartFile("file",
+            "fileOne.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile fileTwo = new MockMultipartFile("file",
+            "fileTwo.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addFile(fileOne);
+        multipartRequest.addFile(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multipartFileMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, MultipartFile> map = (Map<String, MultipartFile>) actual;
+        assertThat(map).containsEntry("file", fileOne);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsPartMap() throws Exception {
+        MockPart fileOne = new MockPart("file_one",
+            "fileOne.txt",
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockPart fileTwo = new MockPart("file_two",
+            "fileTwo.txt",
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addPart(fileOne);
+        multipartRequest.addPart(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("partMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, Part> map = (Map<String, Part>) actual;
+        assertThat(map).containsEntry("file_one", fileOne)
+            .containsEntry("file_two", fileTwo);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsPartMultiValueMap() throws Exception {
+        MockPart fileOne = new MockPart("file",
+            "fileOne.txt",
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockPart fileTwo = new MockPart("file",
+            "fileTwo.txt",
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addPart(fileOne);
+        multipartRequest.addPart(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("multiValuePartMap"), request);
+        assertThat(actual).isInstanceOf(MultiValueMap.class);
+        MultiValueMap<String, Part> map = (MultiValueMap<String, Part>) actual;
+        assertThat(map).containsEntry("file", Arrays.asList(fileOne, fileTwo));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsFirstPartInMap() throws Exception {
+        MockPart fileOne = new MockPart("file",
+            "fileOne.txt",
+            "fileOne".getBytes(StandardCharsets.UTF_8));
+        MockPart fileTwo = new MockPart("file",
+            "fileTwo.txt",
+            "fileTwo".getBytes(StandardCharsets.UTF_8));
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addPart(fileOne);
+        multipartRequest.addPart(fileTwo);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object actual = resolver.resolve(bindingProperty("partMap"), request);
+        assertThat(actual).isInstanceOf(Map.class);
+        Map<String, Part> map = (Map<String, Part>) actual;
+        assertThat(map).containsEntry("file", fileOne);
+    }
+
     private BindingProperty bindingProperty(String property) throws IntrospectionException {
         return BindingProperty.forPropertyDescriptor(new PropertyDescriptor(property, TestingBean.class));
     }
@@ -106,6 +241,18 @@ class RequestParameterMapRequestPropertyResolverTest {
 
         @RequestParameter("irrelevant")
         private Map<String, String> valuePresent;
+
+        @RequestParameter
+        private Map<String, MultipartFile> multipartFileMap;
+
+        @RequestParameter
+        private MultiValueMap<String, MultipartFile> multiValueMultipartMap;
+
+        @RequestParameter
+        private Map<String, Part> partMap;
+
+        @RequestParameter
+        private MultiValueMap<String, Part> multiValuePartMap;
 
         public Map<String, String> getAnnotated() {
             return annotated;
@@ -145,6 +292,38 @@ class RequestParameterMapRequestPropertyResolverTest {
 
         public void setValuePresent(Map<String, String> valuePresent) {
             this.valuePresent = valuePresent;
+        }
+
+        public Map<String, MultipartFile> getMultipartFileMap() {
+            return multipartFileMap;
+        }
+
+        public void setMultipartFileMap(Map<String, MultipartFile> multipartFileMap) {
+            this.multipartFileMap = multipartFileMap;
+        }
+
+        public MultiValueMap<String, MultipartFile> getMultiValueMultipartMap() {
+            return multiValueMultipartMap;
+        }
+
+        public void setMultiValueMultipartMap(MultiValueMap<String, MultipartFile> multiValueMultipartMap) {
+            this.multiValueMultipartMap = multiValueMultipartMap;
+        }
+
+        public Map<String, Part> getPartMap() {
+            return partMap;
+        }
+
+        public void setPartMap(Map<String, Part> partMap) {
+            this.partMap = partMap;
+        }
+
+        public MultiValueMap<String, Part> getMultiValuePartMap() {
+            return multiValuePartMap;
+        }
+
+        public void setMultiValuePartMap(MultiValueMap<String, Part> multiValuePartMap) {
+            this.multiValuePartMap = multiValuePartMap;
         }
     }
 }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
@@ -24,13 +24,14 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.mock.web.MockPart;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Part;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,8 +100,7 @@ class RequestParameterRequestPropertyResolverTest {
         Object actual = resolver.resolve(bindingProperty("multipleValues"), request);
         assertThat(actual).isEqualTo(expected);
     }
-
-    @SuppressWarnings("unchecked")
+    
     @Test
     void returnsMultipartFile() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
@@ -114,7 +114,22 @@ class RequestParameterRequestPropertyResolverTest {
 
         Object actual = resolver.resolve(bindingProperty("multipartFile"), new ServletWebRequest(multipartRequest));
         assertThat(actual).isNotNull();
-        assertThat((Collection<MultipartFile>) actual).hasSize(1).first().isEqualTo(multipartFile);
+        assertThat((MultipartFile) actual).isEqualTo(multipartFile);
+    }
+
+    @Test
+    void returnsPart() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        MockPart part = new MockPart(
+            "part",
+            "testfile.txt",
+            "testing".getBytes(StandardCharsets.UTF_8)
+        );
+        multipartRequest.addPart(part);
+
+        Object actual = resolver.resolve(bindingProperty("part"), new ServletWebRequest(multipartRequest));
+        assertThat(actual).isNotNull();
+        assertThat((Part) actual).isEqualTo(part);
     }
 
     private BindingProperty bindingProperty(String property) throws IntrospectionException {
@@ -136,6 +151,9 @@ class RequestParameterRequestPropertyResolverTest {
 
         @RequestParameter("multipart_file")
         private MultipartFile multipartFile;
+
+        @RequestParameter("part")
+        private Part part;
 
         public String getAnnotated() {
             return annotated;
@@ -175,6 +193,14 @@ class RequestParameterRequestPropertyResolverTest {
 
         public void setMultipartFile(MultipartFile multipartFile) {
             this.multipartFile = multipartFile;
+        }
+
+        public Part getPart() {
+            return part;
+        }
+
+        public void setPart(Part part) {
+            this.part = part;
         }
     }
 }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.web.servlet.mvc.bind.resolver;
 
+import com.mattbertolini.spring.web.bind.PropertyResolutionException;
 import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RequestParameterRequestPropertyResolverTest {
     private RequestParameterRequestPropertyResolver resolver;
@@ -152,6 +154,15 @@ class RequestParameterRequestPropertyResolverTest {
         Object actual = resolver.resolve(bindingProperty("multipartFile"), request);
         assertThat(actual).isNotNull();
         assertThat((MultipartFile) actual).isEqualTo(multipartFile);
+    }
+
+    @Test
+    void throwsExceptionReadingMultipartRequest() {
+        MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multipartFile"), request))
+            .isInstanceOf(PropertyResolutionException.class);
     }
 
     private BindingProperty bindingProperty(String property) throws IntrospectionException {

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
@@ -132,6 +132,28 @@ class RequestParameterRequestPropertyResolverTest {
         assertThat((Part) actual).isEqualTo(part);
     }
 
+    @Test
+    void returnsMultipartFileAndRequestParameter() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile(
+            "multipart_file",
+            "testfile.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "testing".getBytes(StandardCharsets.UTF_8)
+        );
+
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        multipartRequest.addParameter("testing", "value");
+        multipartRequest.addFile(multipartFile);
+        ServletWebRequest request = new ServletWebRequest(multipartRequest);
+
+        Object formValue = resolver.resolve(bindingProperty("annotated"), request);
+        assertThat(formValue).isEqualTo(new String[]{"value"});
+
+        Object actual = resolver.resolve(bindingProperty("multipartFile"), request);
+        assertThat(actual).isNotNull();
+        assertThat((MultipartFile) actual).isEqualTo(multipartFile);
+    }
+
     private BindingProperty bindingProperty(String property) throws IntrospectionException {
         return BindingProperty.forPropertyDescriptor(new PropertyDescriptor(property, TestingBean.class));
     }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,17 @@ import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
 import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,6 +100,23 @@ class RequestParameterRequestPropertyResolverTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsMultipartFile() throws Exception {
+        MockMultipartHttpServletRequest multipartRequest = new MockMultipartHttpServletRequest();
+        MockMultipartFile multipartFile = new MockMultipartFile(
+            "multipart_file",
+            "testfile.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "testing".getBytes(StandardCharsets.UTF_8)
+        );
+        multipartRequest.addFile(multipartFile);
+
+        Object actual = resolver.resolve(bindingProperty("multipartFile"), new ServletWebRequest(multipartRequest));
+        assertThat(actual).isNotNull();
+        assertThat((Collection<MultipartFile>) actual).hasSize(1).first().isEqualTo(multipartFile);
+    }
+
     private BindingProperty bindingProperty(String property) throws IntrospectionException {
         return BindingProperty.forPropertyDescriptor(new PropertyDescriptor(property, TestingBean.class));
     }
@@ -110,6 +133,9 @@ class RequestParameterRequestPropertyResolverTest {
 
         @RequestParameter("multiple_values")
         private List<String> multipleValues;
+
+        @RequestParameter("multipart_file")
+        private MultipartFile multipartFile;
 
         public String getAnnotated() {
             return annotated;
@@ -141,6 +167,14 @@ class RequestParameterRequestPropertyResolverTest {
 
         public void setMultipleValues(List<String> multipleValues) {
             this.multipleValues = multipleValues;
+        }
+
+        public MultipartFile getMultipartFile() {
+            return multipartFile;
+        }
+
+        public void setMultipartFile(MultipartFile multipartFile) {
+            this.multipartFile = multipartFile;
         }
     }
 }

--- a/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
+++ b/spring-webmvc-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/servlet/mvc/bind/resolver/RequestParameterRequestPropertyResolverTest.java
@@ -157,11 +157,12 @@ class RequestParameterRequestPropertyResolverTest {
     }
 
     @Test
-    void throwsExceptionReadingMultipartRequest() {
+    void throwsExceptionReadingMultipartRequest() throws Exception {
         MockMultipartHttpServletRequest multipartRequest = new ExceptionThrowingMockMultipartHttpServletRequest();
         ServletWebRequest request = new ServletWebRequest(multipartRequest);
 
-        assertThatThrownBy(() -> resolver.resolve(bindingProperty("multipartFile"), request))
+        BindingProperty bindingProperty = bindingProperty("multipartFile");
+        assertThatThrownBy(() -> resolver.resolve(bindingProperty, request))
             .isInstanceOf(PropertyResolutionException.class);
     }
 


### PR DESCRIPTION
Basic support for `MultipartFile` and Servlet API `Part` interfaces on the `@RequestParameter` and `@FormParameter` annotations.

This is to support the request in #2