### PR TITLE
Support multipart files using the FormParameter annotation in WebFlux

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This library is my attempt to fill the gap I see in Spring MVC.
 ## Requirements
 
 * Java 8+
-* Spring MVC or Spring WebFlux (5.2.6+)   
+* Spring MVC or Spring WebFlux (5.3.5+)   
 
 ## Use
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.sonarqube' version '2.8'
 }
 
-def springVersion = '5.2.6.RELEASE'
+def springVersion = '5.3.5'
 
 ext {
     projectsWithCoverage = []

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterBean.java
@@ -18,6 +18,7 @@ package com.mattbertolini.spring.test.web.bind;
 
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import com.mattbertolini.spring.web.bind.annotation.FormParameter;
+import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -172,6 +173,22 @@ public class FormParameterBean {
 
         public void setMultiValuePartMap(MultiValueMap<String, Part> multiValuePartMap) {
             this.multiValuePartMap = multiValuePartMap;
+        }
+    }
+
+    /**
+     * Test bean for multipart binding in a WebFlux application
+     */
+    static class WebfluxMultipartBean {
+        @FormParameter("file")
+        private FilePart filePart;
+
+        public FilePart getFilePart() {
+            return filePart;
+        }
+
+        public void setFilePart(FilePart filePart) {
+            this.filePart = filePart;
         }
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/JsonBody.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/JsonBody.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mattbertolini.spring.test.web.bind;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/NestedBean.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/NestedBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mattbertolini.spring.test.web.bind;
 
 import com.mattbertolini.spring.web.bind.annotation.CookieParameter;

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestBodyBean.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestBodyBean.java
@@ -1,7 +1,26 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mattbertolini.spring.test.web.bind;
 
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import com.mattbertolini.spring.web.bind.annotation.RequestBody;
+import org.springframework.http.codec.multipart.Part;
+import org.springframework.util.MultiValueMap;
+import reactor.core.publisher.Flux;
 
 import javax.validation.constraints.NotNull;
 
@@ -89,6 +108,34 @@ public class RequestBodyBean {
 
         public void setNestedBean(NestedBean.RequestBodyBean nestedBean) {
             this.nestedBean = nestedBean;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class WebFluxMultipartMultiValueMap {
+        @RequestBody
+        private MultiValueMap<String, Part> parts;
+
+        public MultiValueMap<String, Part> getParts() {
+            return parts;
+        }
+
+        public void setParts(MultiValueMap<String, Part> parts) {
+            this.parts = parts;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class WebFluxMultipartFlux {
+        @RequestBody
+        private Flux<Part> parts;
+
+        public Flux<Part> getParts() {
+            return parts;
+        }
+
+        public void setParts(Flux<Part> parts) {
+            this.parts = parts;
         }
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestBodyController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestBodyController.java
@@ -1,12 +1,33 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mattbertolini.spring.test.web.bind;
 
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.multipart.Part;
+import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 
 import javax.validation.Valid;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @RestController
 public class RequestBodyController {
@@ -28,6 +49,7 @@ public class RequestBodyController {
         return jsonBody.getProperty();
     }
 
+    @SuppressWarnings("unused")
     @PostMapping(value = "/bindingResult", produces = MediaType.TEXT_PLAIN_VALUE)
     public String bindingResult(@BeanParameter RequestBodyBean.BindingResult requestBodyBean, BindingResult bindingResult) {
         return Integer.toString(bindingResult.getErrorCount());
@@ -38,6 +60,7 @@ public class RequestBodyController {
         return requestBodyBean.getJsonBody().getProperty();
     }
 
+    @SuppressWarnings("unused")
     @PostMapping(value = "/validatedWithBindingResult", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public String validatedWithBindingResult(@Valid @BeanParameter RequestBodyBean.Validation requestBodyBean, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
@@ -49,5 +72,23 @@ public class RequestBodyController {
     @PostMapping(value = "/nested", produces = MediaType.TEXT_PLAIN_VALUE)
     public String nestedBeanParameter(@BeanParameter RequestBodyBean.Nested requestBodyBean) {
         return requestBodyBean.getNestedBean().getRequestBody().getProperty();
+    }
+
+    @PostMapping(value = "/multipartMultiValueMap", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String multipartMultiValueMap(@BeanParameter RequestBodyBean.WebFluxMultipartMultiValueMap requestBodyBean) {
+        MultiValueMap<String, Part> parts = requestBodyBean.getParts();
+        Assert.notEmpty(parts, "Multipart multi-value map is null or empty");
+        return "multipartMultiValueMap " + parts.size();
+    }
+
+    @PostMapping(value = "/multipartFlux", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String multipartFlux(@BeanParameter RequestBodyBean.WebFluxMultipartFlux requestBodyBean) {
+        Flux<Part> parts = requestBodyBean.getParts();
+        AtomicInteger count = new AtomicInteger();
+        parts.collectList().map(partList -> {
+            partList.forEach(part -> count.getAndIncrement());
+            return count.get();
+        }).subscribe();
+        return "multipartFlux " + count.get();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/FormParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/FormParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -30,6 +31,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.reactive.config.EnableWebFlux;
 
 import static org.springframework.web.reactive.function.BodyInserters.fromFormData;
+import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
 
 @SpringJUnitWebConfig(classes = {FormParameterIntegrationTest.Context.class})
 class FormParameterIntegrationTest {
@@ -103,6 +105,23 @@ class FormParameterIntegrationTest {
         makeRequest("/nested", "nested_form_param")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("expectedValue");
+    }
+
+    @Test
+    void bindsMultipartFile() {
+        String expected = "this is a multipart file";
+        MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
+        multipartBodyBuilder.part("file", expected)
+            .contentType(MediaType.TEXT_PLAIN)
+            .filename("mockFile.txt");
+        webTestClient.post()
+            .uri("/webFluxFilePart")
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .body(fromMultipartData(multipartBodyBuilder.build()))
+            .accept(MediaType.TEXT_PLAIN)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo(expected);
     }
 
     private WebTestClient.ResponseSpec makeRequest(String path, String inputParameter) {

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestBodyIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestBodyIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mattbertolini.spring.web.reactive.test;
 
 import com.mattbertolini.spring.test.web.bind.RequestBodyController;
@@ -6,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -13,6 +30,7 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.reactive.config.EnableWebFlux;
 
+import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
 import static org.springframework.web.reactive.function.BodyInserters.fromValue;
 
 @SpringJUnitWebConfig(classes = {RequestBodyIntegrationTest.Context.class})
@@ -74,6 +92,44 @@ class RequestBodyIntegrationTest {
         makeRequest("/nested")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("expectedValue");
+    }
+
+    @Test
+    void bindsMultipartMultiValueMap() {
+        MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
+        multipartBodyBuilder.part("file", "file")
+            .contentType(MediaType.TEXT_PLAIN)
+            .filename("file.txt");
+        multipartBodyBuilder.part("another", "another")
+            .contentType(MediaType.TEXT_PLAIN)
+            .filename("another.txt");
+        webTestClient.post()
+            .uri("/multipartMultiValueMap")
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .body(fromMultipartData(multipartBodyBuilder.build()))
+            .accept(MediaType.TEXT_PLAIN)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("multipartMultiValueMap 2");
+    }
+
+    @Test
+    void bindsMultipartFlux() {
+        MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
+        multipartBodyBuilder.part("file", "file")
+            .contentType(MediaType.TEXT_PLAIN)
+            .filename("file.txt");
+        multipartBodyBuilder.part("another", "another")
+            .contentType(MediaType.TEXT_PLAIN)
+            .filename("another.txt");
+        webTestClient.post()
+            .uri("/multipartFlux")
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .body(fromMultipartData(multipartBodyBuilder.build()))
+            .accept(MediaType.TEXT_PLAIN)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("multipartFlux 2");
     }
 
     private WebTestClient.ResponseSpec makeRequest(String path) {

--- a/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
+++ b/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
@@ -53,12 +53,9 @@ public class FormParameterRequestPropertyResolver implements RequestPropertyReso
 
     @NonNull
     private Object getPartValues(List<Part> parts) {
-        if (!CollectionUtils.isEmpty(parts)) {
-            List<Object> values = parts.stream()
-                .map(value -> value instanceof FormFieldPart ? ((FormFieldPart) value).value() : value)
-                .collect(Collectors.toList());
-            return values.size() == 1 ? values.get(0) : values;
-        }
-        return Mono.empty();
+        List<Object> values = parts.stream()
+            .map(value -> value instanceof FormFieldPart ? ((FormFieldPart) value).value() : value)
+            .collect(Collectors.toList());
+        return values.size() == 1 ? values.get(0) : values;
     }
 }

--- a/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
+++ b/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
@@ -51,7 +51,7 @@ public class FormParameterRequestPropertyResolver implements RequestPropertyReso
     }
 
     @NonNull
-    private Object getPartValues(List<Part> parts) {
+    private Object getPartValues(@NonNull List<Part> parts) {
         List<Object> values = parts.stream()
             .map(value -> value instanceof FormFieldPart ? ((FormFieldPart) value).value() : value)
             .collect(Collectors.toList());

--- a/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
+++ b/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,17 @@ package com.mattbertolini.spring.web.reactive.bind.resolver;
 
 import com.mattbertolini.spring.web.bind.annotation.FormParameter;
 import com.mattbertolini.spring.web.bind.introspect.BindingProperty;
+import org.springframework.http.codec.multipart.FormFieldPart;
+import org.springframework.http.codec.multipart.Part;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class FormParameterRequestPropertyResolver implements RequestPropertyResolver {
     @Override
@@ -36,8 +42,23 @@ public class FormParameterRequestPropertyResolver implements RequestPropertyReso
     public Mono<Object> resolve(@NonNull BindingProperty bindingProperty, @NonNull ServerWebExchange exchange) {
         FormParameter annotation = bindingProperty.getAnnotation(FormParameter.class);
         Assert.state(annotation != null, "No FormParameter annotation found on type");
-        return exchange.getFormData()
-            .filter(multiValueMap -> multiValueMap.getFirst(annotation.value()) != null)
-            .map(multiValueMap -> multiValueMap.get(annotation.value()));
+        return exchange.getMultipartData()
+            .filter(multipartData -> multipartData.getFirst(annotation.value()) != null)
+            .map(multipartData -> multipartData.get(annotation.value()))
+            .map(this::getPartValues)
+            .switchIfEmpty(exchange.getFormData()
+                .filter(formData -> formData.getFirst(annotation.value()) != null)
+                .map(formData -> formData.get(annotation.value())));
+    }
+
+    @NonNull
+    private Object getPartValues(List<Part> parts) {
+        if (!CollectionUtils.isEmpty(parts)) {
+            List<Object> values = parts.stream()
+                .map(value -> value instanceof FormFieldPart ? ((FormFieldPart) value).value() : value)
+                .collect(Collectors.toList());
+            return values.size() == 1 ? values.get(0) : values;
+        }
+        return Mono.empty();
     }
 }

--- a/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
+++ b/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolver.java
@@ -22,7 +22,6 @@ import org.springframework.http.codec.multipart.FormFieldPart;
 import org.springframework.http.codec.multipart.Part;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;

--- a/spring-webflux-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolverTest.java
+++ b/spring-webflux-annotated-data-binder/src/test/java/com/mattbertolini/spring/web/reactive/bind/resolver/FormParameterRequestPropertyResolverTest.java
@@ -144,6 +144,29 @@ class FormParameterRequestPropertyResolverTest {
         assertThat(partContentToString(filePart)).isEqualTo("expected");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void returnsMultipleMultipartFileParts() throws Exception {
+        MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
+        multipartBodyBuilder.part("file", "expectedOne")
+            .contentType(MediaType.TEXT_PLAIN)
+            .filename("mockFileOne.txt");
+        multipartBodyBuilder.part("file", "expectedTwo")
+            .contentType(MediaType.TEXT_PLAIN)
+            .filename("mockFileTwo.txt");
+
+        ServerWebExchange exchange = createMultipartExchange(multipartBodyBuilder);
+        Mono<Object> actual = resolver.resolve(bindingProperty("multipartValue"), exchange);
+        Object obj = actual.block();
+        assertThat(obj).isNotNull()
+            .isInstanceOf(List.class);
+        List<Part> partsList = (List<Part>) obj;
+        for (Part part : partsList) {
+            assertThat(partContentToString(part)).startsWith("expected");
+        }
+
+    }
+
     @Test
     void returnsMultipartFilePartAndFormParameter() throws Exception {
         MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();


### PR DESCRIPTION
Also adding tests to make sure RequestBody annotation works with multipart as well.

Adding missing license headers.