### PR TITLE
Add Preliminary Support for Java Records

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ jobs:
   include:
     - name: OpenJDK 17
       jdk: openjdk17
-      script: ./gradlew --no-daemon jacocoTestReport sonarqube
+      script: ./gradlew --no-daemon jacocoTestReport testCodeCoverageReport sonarqube

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+install: skip
 
 addons:
   sonarcloud:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,8 @@ addons:
 
 jobs:
   include:
-    - name: OpenJDK 8
-      jdk: openjdk8
-      script: ./gradlew jacocoTestReport check
-    - name: OpenJDK 11
-      jdk: openjdk11
+    - name: OpenJDK 17
+      jdk: openjdk17
       script: ./gradlew jacocoTestReport sonarqube
     - name: OpenJDK 17
       jdk: openjdk17

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ jobs:
     - name: OpenJDK 17
       jdk: openjdk17
       script: ./gradlew jacocoTestReport sonarqube
-    - name: OpenJDK 17
-      jdk: openjdk17
-      script: ./gradlew jacocoTestReport check

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ jobs:
   include:
     - name: OpenJDK 17
       jdk: openjdk17
-      script: ./gradlew jacocoTestReport sonarqube
+      script: ./gradlew --no-daemon jacocoTestReport sonarqube

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ public BinderConfiguration binderConfiguration() {
 
 ## Build
 
+### Build Requirements
+
+* Java 17 or above to build. The release jars are compiled to Java 8 bytecode. Integration tests are compiled to Java 17 bytecode.
+
 To build:
 
 ```shell

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.5.0 
+IN PROGRESS
+
+- JDK 17 is now required to build this project. The production artifacts are still compiled to Java 1.8 bytecode.
+- Upgraded to equals verifier 3.10
+
 ## 0.4.0
 Released 2021-06-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 0.5.0 
 IN PROGRESS
 
+- Added preliminary support for Java records.
 - JDK 17 is now required to build this project. The production artifacts are still compiled to Java 1.8 bytecode.
 - Upgraded to equals verifier 3.10
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ val springVersion = "5.3.13"
 val springBootVersion = "2.4.13"
 
 val rootJacocoDir by extra("${rootProject.buildDir}/reports/jacoco/testCodeCoverageReport")
-val reportXmlFile by extra("$rootJacocoDir/jacocoTestReport.xml")
+val reportXmlFile by extra("$rootJacocoDir/testCodeCoverageReport.xml")
 
 val javadocLinks = arrayOf(
     "https://docs.oracle.com/javase/8/docs/api/",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ val reportXmlFile by extra("$rootJacocoDir/jacocoTestReport.xml")
 val javadocLinks = arrayOf(
     "https://docs.oracle.com/javase/8/docs/api/",
     "https://docs.oracle.com/javaee/7/api/",
-    "https://docs.spring.io/spring/docs/$springVersion/javadoc-api/",
+    "https://docs.spring.io/spring-framework/docs/$springVersion/javadoc-api/",
     "https://docs.spring.io/spring-boot/docs/$springBootVersion/api/"
 )
 
@@ -36,8 +36,12 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(8))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
+    }
+
+    tasks.compileJava {
+        options.release.set(8)
     }
 
 //    sourceCompatibility = 1.8
@@ -55,7 +59,7 @@ subprojects {
         // Test
         implementation(platform("org.junit:junit-bom:5.6.1"))
         implementation(platform("org.assertj:assertj-core:3.15.0"))
-        implementation(platform("nl.jqno.equalsverifier:equalsverifier:3.1.13"))
+        implementation(platform("nl.jqno.equalsverifier:equalsverifier:3.10"))
         implementation(platform("org.mockito:mockito-core:3.3.3"))
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,6 +125,6 @@ dependencies {
 sonarqube {
     properties {
         property("sonar.projectKey", "mattbertolini_spring-annotated-web-data-binder")
-//        property "sonar.coverage.jacoco.xmlReportPaths", reportXmlFile
+        property("sonar.coverage.jacoco.xmlReportPaths", reportXmlFile)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     id("org.sonarqube") version "3.3"
 }
 
-val springVersion = "5.3.8"
-val springBootVersion = "2.4.7"
+val springVersion = "5.3.13"
+val springBootVersion = "2.4.13"
 
 val rootJacocoDir by extra("${rootProject.buildDir}/reports/jacoco/testCodeCoverageReport")
 val reportXmlFile by extra("$rootJacocoDir/jacocoTestReport.xml")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     `kotlin-dsl`
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -18,6 +18,10 @@ dependencies {
     testCompileOnly("org.hamcrest:hamcrest") // Version defined in Spring BOM file
 }
 
+tasks.compileJava {
+    options.release.set(17)
+}
+
 tasks.jacocoTestReport {
     reports {
         html.required.set(false)

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/CookieParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/CookieParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.CookieParameterRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindingResult;
@@ -62,5 +63,10 @@ public class CookieParameterController {
     @GetMapping(value = "/nested", produces = MediaType.TEXT_PLAIN_VALUE)
     public String nestedBean(@BeanParameter CookieParameterBean cookieParameterBean) {
         return cookieParameterBean.getNestedBean().getCookieValue();
+    }
+
+    @GetMapping(value = "/record", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String javaRecord(@BeanParameter CookieParameterRecord cookieParameterRecord) {
+        return cookieParameterRecord.annotated();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/FormParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.FormParameterRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -163,5 +164,10 @@ public class FormParameterController {
     @PostMapping(value = "/nested", produces = MediaType.TEXT_PLAIN_VALUE)
     public String nestedBeanParameter(@BeanParameter FormParameterBean formParameterBean) {
         return formParameterBean.getNestedBean().getFormData();
+    }
+
+    @PostMapping(value = "/record", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String javaRecord(@BeanParameter FormParameterRecord formParameterRecord) {
+        return formParameterRecord.annotated();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/HeaderParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/HeaderParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.HeaderParameterRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -83,5 +84,10 @@ public class HeaderParameterController {
     @GetMapping(value = "/nested", produces = MediaType.TEXT_PLAIN_VALUE)
     public String nestedBean(@BeanParameter HeaderParameterBean headerParameterBean) {
         return headerParameterBean.getNestedBean().getHeaderValue();
+    }
+
+    @GetMapping(value = "/record", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String javaRecord(@BeanParameter HeaderParameterRecord headerParameterRecord) {
+        return headerParameterRecord.annotated();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/PathParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/PathParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.PathParameterRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindingResult;
@@ -70,5 +71,10 @@ public class PathParameterController {
     @GetMapping(value = "/nested/{nested_path_param}", produces = MediaType.TEXT_PLAIN_VALUE)
     public String nestedBean(@BeanParameter PathParameterBean pathParameterBean) {
         return pathParameterBean.getNestedBean().getPathVariable();
+    }
+
+    @GetMapping(value = "/record/{annotated_field}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String javaRecord(@BeanParameter PathParameterRecord pathParameterRecord) {
+        return pathParameterRecord.annotated();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestBodyController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestBodyController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.RequestBodyRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.multipart.Part;
@@ -90,5 +91,11 @@ public class RequestBodyController {
             return count.get();
         }).subscribe();
         return "multipartFlux " + count.get();
+    }
+
+    @PostMapping(value = "/record", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    public String javaRecord(@BeanParameter RequestBodyRecord requestBodyRecord) {
+        JsonBody jsonBody = requestBodyRecord.jsonBody();
+        return jsonBody.getProperty();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestContextController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestContextController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.RequestContextRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -72,6 +73,11 @@ public class RequestContextController {
     @GetMapping(value = "/timeZone", produces = MediaType.TEXT_PLAIN_VALUE)
     public String timeZone(@BeanParameter RequestContextBean requestContextBean) {
         return requestContextBean.getTimeZone().toString();
+    }
+
+    @GetMapping(value = "/timeZoneRecord", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String javaRecordTimeZone(@BeanParameter RequestContextRecord requestContextRecord) {
+        return requestContextRecord.timeZone().toString();
     }
 
     @GetMapping(value = "/zoneId", produces = MediaType.TEXT_PLAIN_VALUE)

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,5 +145,10 @@ public class RequestParameterController {
     @GetMapping(value = "/nested", produces = MediaType.TEXT_PLAIN_VALUE)
     public String nestedBeanParameter(@BeanParameter RequestParameterBean requestParameterBean) {
         return requestParameterBean.getNestedBean().getQueryParam();
+    }
+
+    @GetMapping(value = "/record", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String javaRecord(@BeanParameter RequestParameterRecord requestParameterRecord) {
+        return requestParameterRecord.annotated();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterController.java
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.RequestParameterRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/RequestParameterRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind;
+
+import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
+
+public record RequestParameterRecord(
+    @RequestParameter("annotated_field") String annotated
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/SessionParameterController.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/SessionParameterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.mattbertolini.spring.test.web.bind;
 
+import com.mattbertolini.spring.test.web.bind.records.SessionParameterRecord;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindingResult;
@@ -62,5 +63,10 @@ public class SessionParameterController {
     @GetMapping(value = "/nested", produces = MediaType.TEXT_PLAIN_VALUE)
     public String nestedBean(@BeanParameter SessionParameterBean sessionParameterBean) {
         return sessionParameterBean.getNestedBean().getSessionAttribute();
+    }
+
+    @GetMapping(value = "/record", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String javaRecord(@BeanParameter SessionParameterRecord sessionParameterRecord) {
+        return sessionParameterRecord.annotated();
     }
 }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/CookieParameterRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/CookieParameterRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind.records;
+
+import com.mattbertolini.spring.web.bind.annotation.CookieParameter;
+
+public record CookieParameterRecord(
+    @CookieParameter("annotated_field") String annotated
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/FormParameterRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/FormParameterRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind.records;
+
+import com.mattbertolini.spring.web.bind.annotation.FormParameter;
+
+public record FormParameterRecord(
+    @FormParameter("annotated_field") String annotated
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/HeaderParameterRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/HeaderParameterRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind.records;
+
+import com.mattbertolini.spring.web.bind.annotation.HeaderParameter;
+
+public record HeaderParameterRecord(
+    @HeaderParameter("x-annotated-field") String annotated
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/PathParameterRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/PathParameterRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind.records;
+
+import com.mattbertolini.spring.web.bind.annotation.PathParameter;
+
+public record PathParameterRecord(
+    @PathParameter("annotated_field") String annotated
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/RequestBodyRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/RequestBodyRecord.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind.records;
+
+import com.mattbertolini.spring.test.web.bind.JsonBody;
+import com.mattbertolini.spring.web.bind.annotation.RequestBody;
+
+public record RequestBodyRecord(
+    @RequestBody JsonBody jsonBody
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/RequestContextRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/RequestContextRecord.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind.records;
+
+import com.mattbertolini.spring.web.bind.annotation.RequestContext;
+
+import java.util.TimeZone;
+
+public record RequestContextRecord(
+    @RequestContext TimeZone timeZone
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/RequestParameterRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/RequestParameterRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mattbertolini.spring.test.web.bind.records;
+
+import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
+
+public record RequestParameterRecord(
+    @RequestParameter("annotated_field") String annotated
+) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/SessionParameterRecord.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/test/web/bind/records/SessionParameterRecord.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.mattbertolini.spring.test.web.bind;
+package com.mattbertolini.spring.test.web.bind.records;
 
-import com.mattbertolini.spring.web.bind.annotation.RequestParameter;
+import com.mattbertolini.spring.web.bind.annotation.SessionParameter;
 
-public record RequestParameterRecord(
-    @RequestParameter("annotated_field") String annotated
+public record SessionParameterRecord(
+    @SessionParameter("annotated_field") String annotated
 ) {}

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/CookieParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/CookieParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,13 @@ class CookieParameterIntegrationTest {
     @Test
     void bindsNestedBean() {
         makeRequest("/nested", "nested_cookie_param")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("expectedValue");
+    }
+
+    @Test
+    void bindsUsingJavaRecord() {
+        makeRequest("/record", "annotated_field")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("expectedValue");
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/FormParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/FormParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,13 @@ class FormParameterIntegrationTest {
             .exchange()
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo(expected);
+    }
+
+    @Test
+    void bindsUsingJavaRecord() {
+        makeRequest("/record", "annotated_field")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("expectedValue");
     }
 
     private WebTestClient.ResponseSpec makeRequest(String path, String inputParameter) {

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/HeaderParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/HeaderParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,6 +109,13 @@ class HeaderParameterIntegrationTest {
     @Test
     void bindsNestedBean() {
         makeRequest("/nested", "nested_header_param")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("expectedValue");
+    }
+
+    @Test
+    void bindsToJavaRecord() {
+        makeRequest("/record", "x-annotated-field")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("expectedValue");
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/PathParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/PathParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,13 @@ class PathParameterIntegrationTest {
     @Test
     void bindsNestedBean() {
         makeRequest("/nested/expectedValue")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("expectedValue");
+    }
+
+    @Test
+    void bindsUsingJavaRecord() {
+        makeRequest("/record/expectedValue")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("expectedValue");
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestBodyIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestBodyIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,13 @@ class RequestBodyIntegrationTest {
             .exchange()
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("multipartFlux 2");
+    }
+
+    @Test
+    void bindsUsingJavaRecord() {
+        makeRequest("/record")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("expectedValue");
     }
 
     private WebTestClient.ResponseSpec makeRequest(String path) {

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestContextIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestContextIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mattbertolini.spring.web.reactive.test;
 
 import com.mattbertolini.spring.test.web.bind.RequestContextController;
@@ -58,6 +74,13 @@ class RequestContextIntegrationTest {
     @Test
     void bindsTimeZone() {
         makeRequest("/timeZone")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo(TimeZone.getDefault().toString());
+    }
+
+    @Test
+    void bindsTimeZoneJavaRecord() {
+        makeRequest("/timeZoneRecord")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo(TimeZone.getDefault().toString());
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/RequestParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,6 +99,13 @@ class RequestParameterIntegrationTest {
     @Test
     void bindsNestedBean() {
         makeRequest("/nested", "nested_query_param")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("expectedValue");
+    }
+
+    @Test
+    void bindsJavaRecord() {
+        makeRequest("/record", "annotated_field")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("expectedValue");
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/SessionParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/reactive/test/SessionParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,13 @@ class SessionParameterIntegrationTest {
     @Test
     void bindsNestedBean() {
         makeRequest("/nested", "nested_session_param")
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("expectedValue");
+    }
+
+    @Test
+    void bindsUsingJavaRecord() {
+        makeRequest("/record", "annotated_field")
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("expectedValue");
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/CookieParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/CookieParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,15 @@ class CookieParameterIntegrationTest {
         mockMvc.perform(get("/nested")
             .accept(MediaType.TEXT_PLAIN)
             .cookie(new Cookie("nested_cookie_param", "expectedValue")))
+            .andExpect(status().isOk())
+            .andExpect(content().string("expectedValue"));
+    }
+
+    @Test
+    void bindsUsingJavaRecord() throws Exception {
+        mockMvc.perform(get("/record")
+                .accept(MediaType.TEXT_PLAIN)
+                .cookie(new Cookie("annotated_field", "expectedValue")))
             .andExpect(status().isOk())
             .andExpect(content().string("expectedValue"));
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/FormParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,6 +230,13 @@ class FormParameterIntegrationTest {
     @Test
     void bindsNestedBean() throws Exception {
         makeRequest("/nested", "nested_form_param=expectedValue")
+            .andExpect(status().isOk())
+            .andExpect(content().string("expectedValue"));
+    }
+
+    @Test
+    void bindsUsingJavaRecord() throws Exception {
+        makeRequest("/record", "annotated_field=expectedValue")
             .andExpect(status().isOk())
             .andExpect(content().string("expectedValue"));
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/HeaderParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/HeaderParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,13 @@ class HeaderParameterIntegrationTest {
         return mockMvc.perform(get(path)
             .accept(MediaType.TEXT_PLAIN)
             .header(inputHeader, "expectedValue"));
+    }
+
+    @Test
+    void bindsToJavaRecord() throws Exception {
+        makeRequest("/record", "x-annotated-field")
+            .andExpect(status().isOk())
+            .andExpect(content().string("expectedValue"));
     }
 
     @ContextConfiguration

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/PathParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/PathParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,13 @@ class PathParameterIntegrationTest {
     @Test
     void bindsNestedBean() throws Exception {
         makeRequest("/nested/expectedValue")
+            .andExpect(status().isOk())
+            .andExpect(content().string("expectedValue"));
+    }
+
+    @Test
+    void bindsUsingJavaRecord() throws Exception {
+        makeRequest("/record/expectedValue")
             .andExpect(status().isOk())
             .andExpect(content().string("expectedValue"));
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestBodyIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestBodyIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mattbertolini.spring.web.servlet.mvc.test;
 
 import com.mattbertolini.spring.test.web.bind.RequestBodyController;
@@ -76,6 +92,13 @@ class RequestBodyIntegrationTest {
     @Test
     void bindsNestedBean() throws Exception {
         makeRequest("/nested")
+            .andExpect(status().isOk())
+            .andExpect(content().string("expectedValue"));
+    }
+
+    @Test
+    void bindsUsingJavaRecord() throws Exception {
+        makeRequest("/record")
             .andExpect(status().isOk())
             .andExpect(content().string("expectedValue"));
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestContextIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestContextIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,13 @@ class RequestContextIntegrationTest {
         makeRequest("/session")
             .andExpect(status().isOk())
             .andExpect(content().string("expectedValue"));
+    }
+
+    @Test
+    void bindsTimeZoneJavaRecord() throws Exception {
+        makeRequest("/timeZoneRecord")
+            .andExpect(status().isOk())
+            .andExpect(content().string(TimeZone.getDefault().toString()));
     }
 
     private ResultActions makeRequest(String path) throws Exception {

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/RequestParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,6 +231,13 @@ class RequestParameterIntegrationTest {
     @Test
     void bindsNestedBean() throws Exception {
         makeRequest("/nested", "nested_query_param")
+            .andExpect(status().isOk())
+            .andExpect(content().string("expectedValue"));
+    }
+
+    @Test
+    void bindsJavaRecord() throws Exception {
+        makeRequest("/record", "annotated_field")
             .andExpect(status().isOk())
             .andExpect(content().string("expectedValue"));
     }

--- a/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/SessionParameterIntegrationTest.java
+++ b/integration-tests/src/test/java/com/mattbertolini/spring/web/servlet/mvc/test/SessionParameterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,13 @@ class SessionParameterIntegrationTest {
     @Test
     void bindsNestedBean() throws Exception {
         makeRequest("/nested", "nested_session_param")
+            .andExpect(status().isOk())
+            .andExpect(content().string("expectedValue"));
+    }
+
+    @Test
+    void bindsUsingJavaRecord() throws Exception {
+        makeRequest("/record", "annotated_field")
             .andExpect(status().isOk())
             .andExpect(content().string("expectedValue"));
     }

--- a/spring-annotated-data-binder-core/build.gradle.kts
+++ b/spring-annotated-data-binder-core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api("org.springframework:spring-beans")
     api("org.springframework:spring-web")
     compileOnly("com.google.code.findbugs:jsr305")
+    compileOnly("javax.servlet:javax.servlet-api") // So Javadoc doesn't give warnings about missing links
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/BeanParameter.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/BeanParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,32 +24,32 @@ import java.lang.annotation.Target;
 
 /**
  * <p>This annotation has two purposes. The first is to mark controller method arguments for binding using this library.
- * <pre>
- *     &#64;GetMapping(value = "/example", produces = MediaType.TEXT_PLAIN_VALUE)
- *     public String handleRequest(&#64;BeanParameter requestBean) {
+ * <pre>{@code
+ *     @GetMapping(value = "/example", produces = MediaType.TEXT_PLAIN_VALUE)
+ *     public String handleRequest(@BeanParameter requestBean) {
  *         return someService.doSomethingWith(requestBean);
  *     }
- * </pre>
+ * }</pre>
  * The second is to mark a Java bean property as a nested object that should also be scanned for additional request
  * annotations.
- * <pre>
+ * <pre>{@code
  *     public class OuterBean {
- *         &#64;RequestParameter("some_parameter")
+ *         @RequestParameter("some_parameter")
  *         private String someParameter;
  *
- *         &#64;BeanParameter
+ *         @BeanParameter
  *         private NestedBean nestedBean;
  *
  *         // Getters/Setters
  *     }
  *
  *     public class NestedBean {
- *         &#64;RequestParameter("another_parameter")
+ *         @RequestParameter("another_parameter")
  *         private String anotherParameter;
  *
  *         // Getters/Setters
  *     }
- * </pre>
+ * }</pre>
  * <strong>Note:</strong> It's important that no circular dependencies are created using this annotation. The
  * introspection process will fail if a circular reference is found. This is done to prevent stack overflow errors at
  * runtime.</p>

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/CookieParameter.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/CookieParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,30 +26,30 @@ import java.lang.annotation.Target;
  * <p>Annotation for fetching HTTP cookie data.</p>
  *
  * <p>This annotation can be used on fields:
- * <pre>
- *     &#64;CookieParameter("cookie_name")
+ * <pre>{@code
+ *     @CookieParameter("cookie_name")
  *     private String cookieValue;
- * </pre>
+ * }</pre>
  * or on getter/setter methods:
- * <pre>
- *     &#64;CookieParameter("cookie_name")
+ * <pre>{@code
+ *     @CookieParameter("cookie_name")
  *     public void setCookieValue(String cookieValue) {
  *         this.cookieValue = cookieValue;
  *     }
- * </pre>
+ * }</pre>
  * </p>
  *
  * <p>If you need access to all attributes of a cookie (e.g. expiration date, domain, etc) you can bind to cookie
  * objects. In Spring MVC you and bind directly to a {@link javax.servlet.http.Cookie}:
- * <pre>
- *     &#64;CookieParameter("cookie_name")
+ * <pre>{@code
+ *     @CookieParameter("cookie_name")
  *     private Cookie cookie;
- * </pre>
+ * }</pre>
  * In Spring WebFlux you can bind directly to a {@link org.springframework.http.HttpCookie}:
- * <pre>
- *     &#64;CookieParameter("cookie_name")
+ * <pre>{@code
+ *     @CookieParameter("cookie_name")
  *     private HttpCookie cookie;
- * </pre>
+ * }</pre>
  * </p>
  */
 @Target({ElementType.FIELD, ElementType.METHOD})

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/FormParameter.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/FormParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,29 +31,29 @@ import java.lang.annotation.Target;
  * are essentially the same in Spring MVC.</p>
  *
  * <p>This annotation can be used on fields:
- * <pre>
- *     &#64;FormParameter("form_param")
+ * <pre>{@code
+ *     @FormParameter("form_param")
  *     private String formParam;
- * </pre>
+ * }</pre>
  * or on getter/setter methods of the property:
- * <pre>
- *     &#64;FormParameter("form_param")
+ * <pre>{@code
+ *     @FormParameter("form_param")
  *     public void setFormParam(String formParam) {
  *          this.formParam = formParam;
  *     }
- * </pre>
+ * }</pre>
  * </p>
  *
- * <p>Setting this annotation without a value on a {@link java.util.Map} or
- * {@link org.springframework.util.MultiValueMap} binds all of the form data to a map.
- * <pre>
- *     &#64;FormParameter
- *     private MultiValueMap&lt;String, String&gt; formParameters;
+ * <p>Setting this annotation without a value on a {@link java.util.Map Map} or
+ * {@link org.springframework.util.MultiValueMap MultiValueMap} binds all of the form data to a map.
+ * <pre>{@code
+ *     @FormParameter
+ *     private MultiValueMap<String, String> formParameters;
  *
  *     // Map of the first values only
- *     &#64;FormParameter
- *     private Map&lt;String, String&gt; firstParamValues;
- * </pre>
+ *     @FormParameter
+ *     private Map<String, String> firstParamValues;
+ * }</pre>
  * </p>
  */
 @Target({ElementType.FIELD, ElementType.METHOD})

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/HeaderParameter.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/HeaderParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,36 +26,36 @@ import java.lang.annotation.Target;
  * <p>Annotation for fetching HTTP header values.</p>
  *
  * <p>This annotation can be used on fields:
- * <pre>
- *     &#64;HeaderParameter("X-Header-Name")
+ * <pre>{@code
+ *     @HeaderParameter("X-Header-Name")
  *     private String headerValue;
- * </pre>
+ * }</pre>
  * or on getter/setter methods of the property:
- * <pre>
- *     &#64;HeaderParameter("X-Header-Name")
+ * <pre>{@code
+ *     @HeaderParameter("X-Header-Name")
  *     public void setHeaderValue(String headerValue) {
  *         this.headerValue = headerValue;
  *     }
- * </pre>
+ * }</pre>
  * </p>
  *
  * <p>Setting this annotation without a value on a {@link java.util.Map} or
  * {@link org.springframework.util.MultiValueMap} binds all of the headers to a map.
- * <pre>
- *     &#64HeaderParameter
- *     private MultiValueMap&lt;String, String&gt; headers;
+ * <pre>{@code
+ *     @HeaderParameter
+ *     private MultiValueMap<String, String> headers;
  *
  *     // Map of first values only
- *     &#64HeaderParameter
- *     private Map&lt;String, String&gt; firstValueHeaders;
- * </pre>
+ *     @HeaderParameter
+ *     private Map<String, String> firstValueHeaders;
+ * }</pre>
  * </p>
  *
  * <p>This can also be done with a {@link org.springframework.http.HttpHeaders} object as well.
- * <pre>
- *     &#64;HeaderParameter
+ * <pre>{@code
+ *     @HeaderParameter
  *     private HttpHeaders httpHeaders;
- * </pre>
+ * }</pre>
  * </p>
  */
 @Target({ElementType.FIELD, ElementType.METHOD})

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/PathParameter.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/PathParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,24 +26,24 @@ import java.lang.annotation.Target;
  * <p>Annotation for fetching Spring path variable values.</p>
  *
  * <p>This annotation can be used on fields:
- * <pre>
- *     &#64;PathParameter("pathVar")
+ * <pre>{@code
+ *     @PathParameter("pathVar")
  *     private String pathVariable;
- * </pre>
+ * }</pre>
  * or on getter/setter methods:
- * <pre>
- *     &#64;PathParameter("pathVar")
+ * <pre>{@code
+ *     @PathParameter("pathVar")
  *     public void setPathVariable(String pathVariable) {
  *         this.pathVariable = pathVariable;
  *     }
- * </pre>
+ * }</pre>
  * </p>
  *
- * <p>Setting this annotation without a value on a {@link java.util.Map} binds all path variables to a Map.
- * <pre>
- *     &#64;PathParameter
- *     private Map&lt;String, String&gt; pathVariables;
- * </pre>
+ * <p>Setting this annotation without a value on a {@link java.util.Map Map} binds all path variables to a Map.
+ * <pre>{@code
+ *     @PathParameter
+ *     private Map<String, String> pathVariables;
+ * }</pre>
  * </p>
  */
 @Target({ElementType.FIELD, ElementType.METHOD})

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/RequestBean.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/RequestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,15 +28,15 @@ import java.lang.annotation.Target;
  * bean with this annotation found in a package scanned by the introspector will have it's resolved property data
  * pre-loaded and cached so it can be retrieved at request time without the need for additional introspection. This is
  * a performance improvement so introspection is not done at request time.
- * <pre>
- *     &#64;RequestBean
+ * <pre>{@code
+ *     @RequestBean
  *     public class ExampleRequestBean {
- *         &#64RequestParameter("some_parameter")
+ *         @RequestParameter("some_parameter")
  *         private String someParameter;
  *         
  *         // Getters/Setters
  *     }
- * </pre>
+ * }</pre>
  * </p>
  * @see com.mattbertolini.spring.web.bind.introspect.ClassPathScanningAnnotatedRequestBeanIntrospector
  */

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/RequestBody.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/RequestBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,27 +25,27 @@ import java.lang.annotation.Target;
 /**
  * <p>Annotation for fetching the HTTP request body.</p>
  *
- * <p>This annotation leverages the same {@link org.springframework.http.converter.HttpMessageConverter}s in Spring MVC
- * and {@link org.springframework.http.codec.HttpMessageReader}s in Spring WebFlux to convert an HTTP request body into
- * a Java representation.</p>
+ * <p>This annotation leverages the same {@link org.springframework.http.converter.HttpMessageConverter
+ * HttpMessageConverters} in Spring MVC and {@link org.springframework.http.codec.HttpMessageReader HttpMessageReaders}
+ * in Spring WebFlux to convert an HTTP request body into a Java representation.</p>
  *
  * <p>This annotation can be used on fields:
- * <pre>
- *     &#64;RequestBody
+ * <pre>{@code
+ *     @RequestBody
  *     private JsonBody requestBody;
- * </pre>
+ * }</pre>
  * or on getter/setter methods of the property:
- * <pre>
- *     &#64;RequestBody
+ * <pre>{@code
+ *     @RequestBody
  *     public void setRequestBody(JsonBody requestBody) {
  *         this.requestBody = requestBody;
  *     }
- * </pre>
+ * }</pre>
  * </p>
  *
  * <p>This annotation can only be used once per request and cannot be combined with the Spring
- * {@link org.springframework.web.bind.annotation.RequestBody} annotation. This is because the request body InputStream
- * can only be read once per request.</p>
+ * {@link org.springframework.web.bind.annotation.RequestBody RequestBody} annotation. This is because the request body
+ * InputStream can only be read once per request.</p>
  */
 @Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/RequestParameter.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/RequestParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,29 +31,29 @@ import java.lang.annotation.Target;
  * annotation are essentially the same in Spring MVC.</p>
  *
  * <p>This annotation can be used on fields:
- * <pre>
- *     &#64;RequestParameter("query_param")
+ * <pre>{@code
+ *     @RequestParameter("query_param")
  *     private String queryParam;
- * </pre>
+ * }</pre>
  * or on getter/setter methods of the property:
- * <pre>
- *     &#64;RequestParameter("query_param")
+ * <pre>{@code
+ *     @RequestParameter("query_param")
  *     public void setQueryParam(String queryParam) {
  *          this.queryParam = queryParam;
  *     }
- * </pre>
+ * }</pre>
  * </p>
  *
- * <p>Setting this annotation without a value on a {@link java.util.Map} or
- * {@link org.springframework.util.MultiValueMap} binds all of the query parameters to a map.
- * <pre>
- *     &#64;RequestParameter
- *     private MultiValueMap&lt;String, String&gt; queryParameters;
+ * <p>Setting this annotation without a value on a {@link java.util.Map Map} or
+ * {@link org.springframework.util.MultiValueMap MultiValueMap} binds all of the query parameters to a map.
+ * <pre>{@code
+ *     @RequestParameter
+ *     private MultiValueMap<String, String> queryParameters;
  *
  *     // Map of the first values only
- *     &#64;RequestParameter
- *     private Map&lt;String, String&gt; firstParamValues;
- * </pre>
+ *     @RequestParameter
+ *     private Map<String, String> firstParamValues;
+ * }</pre>
  * </p>
  */
 @Target({ElementType.FIELD, ElementType.METHOD})

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/SessionParameter.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/annotation/SessionParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,17 +26,17 @@ import java.lang.annotation.Target;
  * <p>Annotation for fetching session attributes.</p>
  *
  * <p>This annotation can be used on fields:
- * <pre>
- *     &#64;SessionParameter("attributeName")
+ * <pre>{@code
+ *     @SessionParameter("attributeName")
  *     private String attributeName;
- * </pre>
+ * }</pre>
  * or on getter/setter methods:
- * <pre>
- *     &#64;SessionParameter("attributeName")
+ * <pre>{@code
+ *     @SessionParameter("attributeName")
  *     public void setAttributeName(String attributeName) {
  *         this.attributeName = attributeName;
  *     }
- * </pre>
+ * }</pre>
  * </p>
  */
 @Target({ElementType.FIELD, ElementType.METHOD})

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/AnnotatedRequestBeanIntrospector.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/AnnotatedRequestBeanIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,34 @@ package com.mattbertolini.spring.web.bind.introspect;
 
 import org.springframework.lang.NonNull;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 public interface AnnotatedRequestBeanIntrospector {
+
+    /**
+     * Creates a map of resolved property data for the given target class. This method traverses the object graph for
+     * the given type recursively. Circular references are not allowed as they will cause stack overflow errors.
+     *
+     * @param targetType The class or type to get property resolver data for. Required.
+     * @return A map of resolved property data. This map is never null but may be empty.
+     * @throws CircularReferenceException If a circular reference is found while traversing the object graph.
+     */
     @NonNull
-    List<ResolvedPropertyData> getResolversFor(@NonNull Class<?> targetType);
+    Map<String, ResolvedPropertyData> getResolverMapFor(@NonNull Class<?> targetType);
+
+    /**
+     * Creates a list of resolved property data for the given target class. This method traverses the object graph for
+     * the given type recursively. Circular references are not allowed as they will cause stack overflow errors.
+     *
+     * @param targetType The class or type to get property resolver data for. Required.
+     * @return A list of resolved property data. This list is never null but may be empty.
+     * @throws CircularReferenceException If a circular reference is found while traversing the object graph.
+     */
+    @NonNull
+    default Collection<ResolvedPropertyData> getResolversFor(@NonNull Class<?> targetType) {
+        Map<String, ResolvedPropertyData> propertyData = getResolverMapFor(targetType);
+        return Collections.unmodifiableCollection(propertyData.values());
+    }
 }

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/CachedAnnotatedRequestBeanIntrospector.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/CachedAnnotatedRequestBeanIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@ package com.mattbertolini.spring.web.bind.introspect;
 
 import org.springframework.lang.NonNull;
 
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class CachedAnnotatedRequestBeanIntrospector implements AnnotatedRequestBeanIntrospector {
     private final AnnotatedRequestBeanIntrospector delegate;
-    private final ConcurrentMap<Class<?>, List<ResolvedPropertyData>> cache;
+    private final ConcurrentMap<Class<?>, Map<String, ResolvedPropertyData>> cache;
 
     public CachedAnnotatedRequestBeanIntrospector(@NonNull AnnotatedRequestBeanIntrospector delegate) {
         this.delegate = delegate;
@@ -33,7 +33,7 @@ public class CachedAnnotatedRequestBeanIntrospector implements AnnotatedRequestB
 
     @Override
     @NonNull
-    public List<ResolvedPropertyData> getResolversFor(@NonNull Class<?> targetType) {
-        return cache.computeIfAbsent(targetType, delegate::getResolversFor);
+    public Map<String, ResolvedPropertyData> getResolverMapFor(@NonNull Class<?> targetType) {
+        return cache.computeIfAbsent(targetType, delegate::getResolverMapFor);
     }
 }

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/ClassPathScanningAnnotatedRequestBeanIntrospector.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/ClassPathScanningAnnotatedRequestBeanIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class ClassPathScanningAnnotatedRequestBeanIntrospector implements AnnotatedRequestBeanIntrospector, InitializingBean {
@@ -51,8 +51,8 @@ public class ClassPathScanningAnnotatedRequestBeanIntrospector implements Annota
 
     @Override
     @NonNull
-    public List<ResolvedPropertyData> getResolversFor(@NonNull Class<?> targetType) {
-        return introspectorCache.getResolversFor(targetType);
+    public Map<String, ResolvedPropertyData> getResolverMapFor(@NonNull Class<?> targetType) {
+        return introspectorCache.getResolverMapFor(targetType);
     }
 
     @Override
@@ -75,8 +75,8 @@ public class ClassPathScanningAnnotatedRequestBeanIntrospector implements Annota
             try {
                 LOGGER.debug("Introspecting request bean " + beanClassName);
                 Class<?> clazz = ClassUtils.forName(beanClassName, classLoader);
-                // Invoking cache getResolversFor will trigger the delegate introspector and save data into the cache.
-                introspectorCache.getResolversFor(clazz);
+                // Invoking cache getResolverMapFor will trigger the delegate introspector and save data into the cache.
+                introspectorCache.getResolverMapFor(clazz);
             } catch (Exception e) {
                 throw new RequestBeanIntrospectionException("Unable to introspect request bean of type " + beanClassName + ": " + e.getMessage(), e);
             }

--- a/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/DefaultAnnotatedRequestBeanIntrospector.java
+++ b/spring-annotated-data-binder-core/src/main/java/com/mattbertolini/spring/web/bind/introspect/DefaultAnnotatedRequestBeanIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,10 @@ import com.mattbertolini.spring.web.bind.AbstractPropertyResolverRegistry;
 import com.mattbertolini.spring.web.bind.annotation.BeanParameter;
 import com.mattbertolini.spring.web.bind.resolver.RequestPropertyResolverBase;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeansException;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -65,14 +63,13 @@ public class DefaultAnnotatedRequestBeanIntrospector implements AnnotatedRequest
                                           @Nullable final String prefix,
                                           @NonNull final List<ResolvedPropertyData> propertyData,
                                           @NonNull final Set<Class<?>> cycleClasses) {
-        BeanInfo beanInfo;
+        PropertyDescriptor[] propertyDescriptors;
         try {
-            beanInfo = Introspector.getBeanInfo(targetType);
-        } catch (IntrospectionException e) {
+            propertyDescriptors = BeanUtils.getPropertyDescriptors(targetType);
+        } catch (BeansException e) {
             throw new RequestBeanIntrospectionException("Unable to introspect request bean of type " +
                 targetType.getName() + ": " + e.getMessage(), e);
         }
-        PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
         for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
             String propertyName = getPropertyName(prefix, propertyDescriptor);
             BindingProperty bindingProperty = BindingProperty.forPropertyDescriptor(propertyDescriptor);

--- a/spring-annotated-data-binder-core/src/test/java/com/mattbertolini/spring/web/bind/introspect/ClassPathScanningAnnotatedRequestBeanIntrospectorTest.java
+++ b/spring-annotated-data-binder-core/src/test/java/com/mattbertolini/spring/web/bind/introspect/ClassPathScanningAnnotatedRequestBeanIntrospectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import com.mattbertolini.spring.web.bind.introspect.scan.subbackage.SubpackageBe
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,9 +49,9 @@ class ClassPathScanningAnnotatedRequestBeanIntrospectorTest {
         Set<String> packages = Collections.singleton("com.mattbertolini.spring.web.bind.introspect.scan");
         ClassPathScanningAnnotatedRequestBeanIntrospector introspector = new ClassPathScanningAnnotatedRequestBeanIntrospector(delegateIntrospector, packages);
         introspector.afterPropertiesSet();
-        verify(delegateIntrospector).getResolversFor(ScannedBean.class);
-        verify(delegateIntrospector).getResolversFor(SubpackageBean.class);
-        verify(delegateIntrospector, never()).getResolversFor(IgnoredBean.class);
+        verify(delegateIntrospector).getResolverMapFor(ScannedBean.class);
+        verify(delegateIntrospector).getResolverMapFor(SubpackageBean.class);
+        verify(delegateIntrospector, never()).getResolverMapFor(IgnoredBean.class);
     }
 
     @Test
@@ -64,7 +64,7 @@ class ClassPathScanningAnnotatedRequestBeanIntrospectorTest {
 
     @Test
     void throwsExceptionWhenResolving() {
-        when(delegateIntrospector.getResolversFor(any())).thenThrow(RuntimeException.class);
+        when(delegateIntrospector.getResolverMapFor(any())).thenThrow(RuntimeException.class);
         Set<String> packages = Collections.singleton("com.mattbertolini.spring.web.bind.introspect.scan");
         ClassPathScanningAnnotatedRequestBeanIntrospector introspector = new ClassPathScanningAnnotatedRequestBeanIntrospector(delegateIntrospector, packages);
         assertThatThrownBy(introspector::afterPropertiesSet).isInstanceOf(RequestBeanIntrospectionException.class);
@@ -75,8 +75,8 @@ class ClassPathScanningAnnotatedRequestBeanIntrospectorTest {
         Set<String> packages = Collections.singleton("com.mattbertolini.spring.web.bind.introspect.scan");
         ClassPathScanningAnnotatedRequestBeanIntrospector introspector = new ClassPathScanningAnnotatedRequestBeanIntrospector(delegateIntrospector, packages);
         introspector.afterPropertiesSet();
-        List<ResolvedPropertyData> resolversFor = introspector.getResolversFor(ScannedBean.class);
+        Collection<ResolvedPropertyData> resolversFor = introspector.getResolversFor(ScannedBean.class);
         assertThat(resolversFor).isNotNull();
-        verify(delegateIntrospector).getResolversFor(ScannedBean.class);
+        verify(delegateIntrospector).getResolverMapFor(ScannedBean.class);
     }
 }

--- a/spring-annotated-data-binder-core/src/test/java/com/mattbertolini/spring/web/bind/introspect/DefaultAnnotatedRequestBeanIntrospectorTest.java
+++ b/spring-annotated-data-binder-core/src/test/java/com/mattbertolini/spring/web/bind/introspect/DefaultAnnotatedRequestBeanIntrospectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.lang.NonNull;
 
 import java.lang.annotation.Annotation;
-import java.util.List;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,9 +50,9 @@ class DefaultAnnotatedRequestBeanIntrospectorTest {
     void returnsResolversForType() {
         FakeResolver resolver = new FakeResolver(RequestParameter.class);
         registry.addResolver(resolver);
-        List<ResolvedPropertyData> resolvers = introspector.getResolversFor(SimpleType.class);
+        Collection<ResolvedPropertyData> resolvers = introspector.getResolversFor(SimpleType.class);
         assertThat(resolvers.size()).isEqualTo(1);
-        ResolvedPropertyData data = resolvers.get(0);
+        ResolvedPropertyData data = resolvers.iterator().next();
         assertThat(data.getPropertyName()).isEqualTo("data");
     }
 
@@ -60,9 +60,9 @@ class DefaultAnnotatedRequestBeanIntrospectorTest {
     void returnsResolversUsingNestedTypes() {
         FakeResolver resolver = new FakeResolver(RequestParameter.class);
         registry.addResolver(resolver);
-        List<ResolvedPropertyData> resolvers = introspector.getResolversFor(OuterBean.class);
+        Collection<ResolvedPropertyData> resolvers = introspector.getResolversFor(OuterBean.class);
         assertThat(resolvers.size()).isEqualTo(1);
-        ResolvedPropertyData data = resolvers.get(0);
+        ResolvedPropertyData data = resolvers.iterator().next();
         assertThat(data.getPropertyName()).isEqualTo("innerBean.inner");
     }
 

--- a/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/BeanParameterMethodArgumentResolver.java
+++ b/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/BeanParameterMethodArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,13 @@ import com.mattbertolini.spring.web.reactive.bind.resolver.RequestPropertyResolv
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.ReactiveAdapter;
 import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.core.ResolvableType;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.support.WebExchangeDataBinder;
+import org.springframework.web.reactive.BindingContext;
 import org.springframework.web.reactive.result.method.annotation.ModelAttributeMethodArgumentResolver;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
@@ -36,11 +39,13 @@ import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 
 public class BeanParameterMethodArgumentResolver extends ModelAttributeMethodArgumentResolver {
+    private static final String INTROSPECTOR_RESOLVABLE_TYPE = BeanParameterMethodArgumentResolver.class.getName()
+        + ".INTROSPECTOR_RESOLVABLE_TYPE";
 
     private final AnnotatedRequestBeanIntrospector introspector;
 
@@ -58,17 +63,43 @@ public class BeanParameterMethodArgumentResolver extends ModelAttributeMethodArg
 
     @Override
     @NonNull
+    public Mono<Object> resolveArgument(@NonNull MethodParameter parameter, @NonNull BindingContext context, ServerWebExchange exchange) {
+        try {
+            ResolvableType type = ResolvableType.forMethodParameter(parameter);
+            Class<?> resolvedType = type.resolve();
+            ReactiveAdapter adapter = (resolvedType != null ? getAdapterRegistry().getAdapter(resolvedType) : null);
+            ResolvableType valueType = (adapter != null ? type.getGeneric() : type);
+            exchange.getAttributes().put(INTROSPECTOR_RESOLVABLE_TYPE, valueType);
+            return super.resolveArgument(parameter, context, exchange);
+        } finally {
+            exchange.getAttributes().remove(INTROSPECTOR_RESOLVABLE_TYPE);
+        }
+    }
+
+    @Override
+    @NonNull
     protected Mono<Void> bindRequestParameters(@NonNull WebExchangeDataBinder binder, @NonNull ServerWebExchange exchange) {
         Assert.state(binder.getTarget() != null, "WebExchangeDataBinder must have a target object");
-        List<ResolvedPropertyData> propertyData = introspector.getResolversFor(binder.getTarget().getClass());
+        Collection<ResolvedPropertyData> propertyData = introspector.getResolversFor(binder.getTarget().getClass());
         return getValuesToBind(propertyData, exchange)
             .map(MutablePropertyValues::new)
             .doOnNext(binder::bind)
             .then();
     }
 
+    @Override
     @NonNull
-    private Mono<Map<String, Object>> getValuesToBind(@NonNull List<ResolvedPropertyData> propertyData, @NonNull ServerWebExchange exchange) {
+    public Mono<Map<String, Object>> getValuesToBind(@NonNull WebExchangeDataBinder binder, ServerWebExchange exchange) {
+        ResolvableType resolvableType = exchange.getAttribute(INTROSPECTOR_RESOLVABLE_TYPE);
+        if (resolvableType == null) {
+            return super.getValuesToBind(binder, exchange);
+        }
+        Collection<ResolvedPropertyData> propertyData = introspector.getResolversFor(resolvableType.resolve());
+        return getValuesToBind(propertyData, exchange);
+    }
+
+    @NonNull
+    private Mono<Map<String, Object>> getValuesToBind(@NonNull Collection<ResolvedPropertyData> propertyData, @NonNull ServerWebExchange exchange) {
         return Flux.fromIterable(propertyData).flatMap(data -> {
             BindingProperty bindingProperty = data.getBindingProperty();
             RequestPropertyResolver resolver = (RequestPropertyResolver) data.getResolver();

--- a/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/BeanParameterMethodArgumentResolver.java
+++ b/spring-webflux-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/reactive/bind/BeanParameterMethodArgumentResolver.java
@@ -94,7 +94,9 @@ public class BeanParameterMethodArgumentResolver extends ModelAttributeMethodArg
         if (resolvableType == null) {
             return super.getValuesToBind(binder, exchange);
         }
-        Collection<ResolvedPropertyData> propertyData = introspector.getResolversFor(resolvableType.resolve());
+        Class<?> type = resolvableType.resolve();
+        Assert.notNull(type, "The resolved type must not be null");
+        Collection<ResolvedPropertyData> propertyData = introspector.getResolversFor(type);
         return getValuesToBind(propertyData, exchange);
     }
 

--- a/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/BeanParameterMethodArgumentResolver.java
+++ b/spring-webmvc-annotated-data-binder/src/main/java/com/mattbertolini/spring/web/servlet/mvc/bind/BeanParameterMethodArgumentResolver.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.method.annotation.ModelAttributeMethodProcessor;
 
 import java.util.Collection;
@@ -89,16 +89,16 @@ public class BeanParameterMethodArgumentResolver extends ModelAttributeMethodPro
         try {
             MethodParameter nestedParameter = parameter.nestedIfOptional();
             Class<?> clazz = nestedParameter.getNestedParameterType();
-            webRequest.setAttribute(INTROSPECTOR_TARGET_CLASS, clazz, WebRequest.SCOPE_REQUEST);
+            webRequest.setAttribute(INTROSPECTOR_TARGET_CLASS, clazz, RequestAttributes.SCOPE_REQUEST);
             return super.createAttribute(attributeName, parameter, binderFactory, webRequest);
         } finally {
-            webRequest.removeAttribute(INTROSPECTOR_TARGET_CLASS, WebRequest.SCOPE_REQUEST);
+            webRequest.removeAttribute(INTROSPECTOR_TARGET_CLASS, RequestAttributes.SCOPE_REQUEST);
         }
     }
 
     @Override
     public Object resolveConstructorArgument(@NonNull String paramName,@NonNull Class<?> paramType, NativeWebRequest request) throws Exception {
-        Class<?> clazz = (Class<?>) request.getAttribute(INTROSPECTOR_TARGET_CLASS, WebRequest.SCOPE_REQUEST);
+        Class<?> clazz = (Class<?>) request.getAttribute(INTROSPECTOR_TARGET_CLASS, RequestAttributes.SCOPE_REQUEST);
         if (clazz == null) {
             return super.resolveConstructorArgument(paramName, paramType, request);
         }


### PR DESCRIPTION
This is to support Java records as requested in #6. This support is based on constructor binding support that exists in Spring already.

This means that JDK 17 is required to build the library but the bytecode is still compiled as JDK 8.